### PR TITLE
Persist preprocessing queue to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ Make sure you have Python development headers installed, as some libraries (such
 ## Companion app för bildvisning
 
 App som används för att visa bild, taggat med labels på ansikten, är som förval kompanjon-appen [Bildvisare](https://github.com/krissen/bildvisare). Detta kan justeras i inställningar.
+
+## Preprocessed cache
+
+Intermediate preprocessing results are written as pickled files under `preprocessed_cache/`. The program reloads any cached entries into the preprocessing queue on startup so an interrupted run can resume. Cache files are deleted once the main loop consumes an entry.


### PR DESCRIPTION
## Summary
- cache `(path, attempt_results)` pairs from `preprocess_worker` to `preprocessed_cache/`
- reload cached entries into the queue on startup and remove cache files when consumed
- document persistent preprocessing cache in README

## Testing
- `python -m py_compile hitta_ansikten.py`
- `pytest >/tmp/pytest.log 2>&1; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a09a233268832886bca6fe76c5dbbd