### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,13 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: backend/pyproject.toml
 
       - name: Install Python dependencies
         working-directory: backend
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pyinstaller
+          pip install ".[build]"
 
       - name: Build backend with PyInstaller
         working-directory: backend
@@ -101,14 +100,13 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: backend/pyproject.toml
 
       - name: Install Python dependencies
         working-directory: backend
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pyinstaller
+          pip install ".[build]"
 
       - name: Build backend with PyInstaller
         working-directory: backend
@@ -173,7 +171,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: backend/pyproject.toml
 
       - name: Install system dependencies
         run: |
@@ -184,8 +182,7 @@ jobs:
         working-directory: backend
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pyinstaller
+          pip install ".[build]"
 
       - name: Build backend with PyInstaller
         working-directory: backend

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,8 @@
+{
+  "workspace.ignoreDir": [
+    "backend/.venv",
+    "backend/dist",
+    "frontend/dist",
+    "frontend/resources"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-20
+
 ### Added
 - Added file queue filter bar (`/` or `Cmd+F`): filter the file list by filename pattern, with match count indicator. Actions like rename and clear-done scope to filtered items when no checkbox selection exists.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+### Fixed
+- Fixed Cmd+/Cmd- zoom never stopping: `useKeyHold` now ignores Cmd/Ctrl combos (handled by menu accelerators) and matches keyup by physical key code to avoid stuck animation loops when Shift is released before the base key.
+- Fixed menu zoom clicks (Zoom In/Out, Reset, Auto-Fit) having no effect due to stale closures captured at mount time in `useModuleEvent` handlers.
+- Fixed first double-click in file queue showing an empty image viewer: `loadFile` now waits for ImageViewer's `load-image` listener before emitting, handling the async gap when `tabEnableRenderOnDemand` causes deferred mounting.
+- Fixed `useKeyHold` cleanup using `clearInterval` instead of `cancelAnimationFrame` for rAF-based animation loops.
+
 ### Changed
 - Replaced conda/hardcoded Python paths with convention-based venv discovery (`backend/.venv/`).
 - Migrated dependency management from `requirements.txt` to `pyproject.toml` (PEP 621).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+### Added
+- Added file queue filter bar (`/` or `Cmd+F`): filter the file list by filename pattern, with match count indicator. Actions like rename and clear-done scope to filtered items when no checkbox selection exists.
+
 ### Fixed
 - Fixed Cmd+/Cmd- zoom never stopping: `useKeyHold` now ignores Cmd/Ctrl combos (handled by menu accelerators) and matches keyup by physical key code to avoid stuck animation loops when Shift is released before the base key.
 - Fixed menu zoom clicks (Zoom In/Out, Reset, Auto-Fit) having no effect due to stale closures captured at mount time in `useModuleEvent` handlers.
 - Fixed first double-click in file queue showing an empty image viewer: `loadFile` now waits for ImageViewer's `load-image` listener before emitting, handling the async gap when `tabEnableRenderOnDemand` causes deferred mounting.
 - Fixed `useKeyHold` cleanup using `clearInterval` instead of `cancelAnimationFrame` for rAF-based animation loops.
+- Separated focused state from checkbox selection in file queue: plain click highlights an item without checking its checkbox; checkboxes require explicit click, Cmd+Click, or Shift+Click.
 
 ### Changed
 - Replaced conda/hardcoded Python paths with convention-based venv discovery (`backend/.venv/`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+This changelog is initialized from git commit history after `v1.0.0` and can be refined before upcoming releases.
+
+## [Unreleased]
+
+### Changed
+- Replaced conda/hardcoded Python paths with convention-based venv discovery (`backend/.venv/`).
+- Migrated dependency management from `requirements.txt` to `pyproject.toml` (PEP 621).
+- Moved pytest config from `pytest.ini` into `pyproject.toml`.
+- Updated CI workflow to install from `pyproject.toml` with optional dependency groups.
+- Updated all documentation to use `.venv` and `pip install -e ".[dev]"`.
+- Updated release spec references from `bildvisare` to `ansikten`.
+
+### Removed
+- Removed obsolete planning and theme example files.
+
+## [1.1.0] - 2026-01-11
+
+### Added
+- Added undo stack for face actions and ESC cancel support in review.
+- Added backend log streaming to LogViewer over WebSocket and a copy action (`Cmd/Ctrl+A` support).
+- Added drag-and-drop support in File Queue.
+- Added sidecar file handling in rename flows and sidecar indicators in preview.
+- Added JSON Schema for shared type definitions.
+- Added pytest and vitest setup with example tests.
+
+### Changed
+- Rebranded app naming from Bildvisare/hitta_ansikten to Ansikten across code and documentation.
+- Migrated API routes to `/api/v1/` prefix.
+- Improved WebSocket reconnect behavior (cap + jitter) and API client offline/network timeout handling.
+- Refactored `hitta_ansikten.py` by extracting config, image, and matching modules.
+- Consolidated frontend logging via `debug.js` and expanded health endpoint component status.
+
+### Fixed
+- Fixed basename collision issues by moving review matching to hash-based logic.
+- Fixed rename pipeline to include manual faces and rename only selected files when selection exists.
+- Fixed broken thumbnails and missing API version in thumbnail URLs.
+- Fixed spammy statistics summary requests and improved auto-refresh stability.
+- Fixed multiple ReviewModule UX issues (tab behavior, focus feedback, face index sync, auto-advance edge cases).
+- Fixed light theme button hover state and improved theme variables for confirmed/ignored face states.
+
+### Docs
+- Updated testing, shortcuts, install/release guides, and rebranding documentation.
+
+### Build
+- Added bundle analysis and removed unused dockview dependency.
+
+## [1.0.1] - 2026-01-10
+
+### Changed
+- Improved backend packaging by excluding unused dependencies from backend spec.
+- Added Electron cache in release workflow for faster CI builds.
+- Improved release workflow reliability (skip redundant backend build, fixed PyInstaller onedir copying).
+- Improved macOS build handling for symlinks in backend copy step.
+
+### Fixed
+- Fixed preprocessing manager state reset when stopping/clearing/renaming.
+- Fixed review behavior to avoid auto-advance when no faces are detected.
+- Fixed statistics to include additional attempt/resolution data from existing records.
+
+## [1.0.0] - 2026-01-09
+
+- Initial stable release tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 - Fixed first double-click in file queue showing an empty image viewer: `loadFile` now waits for ImageViewer's `load-image` listener before emitting, handling the async gap when `tabEnableRenderOnDemand` causes deferred mounting.
 - Fixed `useKeyHold` cleanup using `clearInterval` instead of `cancelAnimationFrame` for rAF-based animation loops.
 - Separated focused state from checkbox selection in file queue: plain click highlights an item without checking its checkbox; checkboxes require explicit click, Cmd+Click, or Shift+Click.
+- Fixed non-image files (XMP sidecars, etc.) being added to queue from glob patterns. File extension filtering now applied in `addFiles()`, `expandFilePaths()`, and the `expand-glob` IPC handler.
 
 ### Changed
 - Replaced conda/hardcoded Python paths with convention-based venv discovery (`backend/.venv/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,8 @@ npx electron .                             # Run app (auto-starts backend on :50
 
 ```bash
 cd backend
-pip install -r requirements.txt
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
 python -m api.server                       # Run API server standalone
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The tool is designed for sports events, school activities, or any context where 
 
 ```bash
 cd backend
-pip install -r requirements.txt
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e "."
 
 # Process images
 ./hitta_ansikten.py 2024*.NEF

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.so
 venv/
 .venv/
+*.egg-info/
 
 # PyInstaller
 build/

--- a/backend/api/routes/detection.py
+++ b/backend/api/routes/detection.py
@@ -82,6 +82,27 @@ class ReloadDatabaseResponse(BaseModel):
     cache_cleared: int
 
 
+class BatchConfirmItem(BaseModel):
+    face_id: str
+    person_name: str
+    image_path: str
+    suggested_name: Optional[str] = None
+
+class BatchIgnoreItem(BaseModel):
+    face_id: str
+    image_path: str
+
+class BatchConfirmRequest(BaseModel):
+    confirmations: List[BatchConfirmItem] = []
+    ignores: List[BatchIgnoreItem] = []
+
+class BatchConfirmResponse(BaseModel):
+    status: str
+    confirmed_count: int
+    ignored_count: int
+    errors: List[dict] = []
+
+
 class ReviewedFace(BaseModel):
     face_index: int
     face_id: str
@@ -295,6 +316,27 @@ async def ignore_face(request: IgnoreFaceRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"[Detection] Error ignoring face: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/batch-confirm", response_model=BatchConfirmResponse)
+async def batch_confirm(request: BatchConfirmRequest):
+    """
+    Batch confirm/ignore multiple faces with a single database save.
+
+    More efficient than individual confirm/ignore calls when processing
+    all faces in an image at once.
+    """
+    logger.info(f"[Detection] Batch confirm: {len(request.confirmations)} confirms, {len(request.ignores)} ignores")
+
+    try:
+        result = await get_detection_service().batch_confirm(
+            [c.model_dump() for c in request.confirmations],
+            [i.model_dump() for i in request.ignores]
+        )
+        return BatchConfirmResponse(**result)
+    except Exception as e:
+        logger.error(f"[Detection] Error in batch confirm: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/api/services/detection_service.py
+++ b/backend/api/services/detection_service.py
@@ -1003,6 +1003,13 @@ class DetectionService:
             await self._flush_save()  # Immediate save — review is finalized
             logger.info(f"[DetectionService] Added {file_name} to processed_files")
 
+        # Invalidate statistics cache so dashboard picks up new data
+        try:
+            from .statistics_service import statistics_service
+            statistics_service.invalidate_cache()
+        except Exception:
+            pass  # Non-critical
+
         return {
             "status": "success",
             "message": f"Review logged for {len(labels)} faces",

--- a/backend/api/services/detection_service.py
+++ b/backend/api/services/detection_service.py
@@ -4,11 +4,14 @@ Detection Service
 Wraps existing face detection logic from the Ansikten CLI.
 """
 
+import asyncio
 import logging
 import os
 import sys
 import time
 import hashlib
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Any, Optional, Tuple
 from pathlib import Path
 from datetime import datetime
@@ -27,6 +30,14 @@ from .preprocessing_cache import get_cache as get_preprocessing_cache
 
 logger = logging.getLogger(__name__)
 
+# Thread pool for offloading blocking I/O (hash computation, image loading, face detection)
+_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="detection")
+
+# Cache size limits (LRU eviction)
+MAX_DETECTION_CACHE = 100
+MAX_ENCODING_CACHE = 1000
+MAX_IMAGE_CACHE = 10
+
 class DetectionService:
     """Face detection service wrapper"""
 
@@ -43,16 +54,76 @@ class DetectionService:
         self.known_faces, self.ignored_faces, self.hard_negatives, self.processed_files = load_database()
         logger.info(f"[DetectionService] Loaded database: {len(self.known_faces)} people, {len(self.ignored_faces)} ignored faces")
 
-        # Cache for detection results (keyed by file hash)
-        self.cache: Dict[str, Dict[str, Any]] = {}
+        # LRU caches using OrderedDict (move_to_end on access, popitem(last=False) to evict)
+        # Detection results cache (keyed by file hash)
+        self.cache: OrderedDict[str, Dict[str, Any]] = OrderedDict()
 
-        # Cache for face encodings (keyed by face_id for confirm/ignore operations)
-        self.encoding_cache: Dict[str, Tuple[np.ndarray, Dict[str, int]]] = {}
+        # Face encoding cache (keyed by face_id) — stores (encoding, bbox, file_hash)
+        self.encoding_cache: OrderedDict[str, Tuple[np.ndarray, Dict[str, int], Optional[str]]] = OrderedDict()
 
-        # Cache for loaded images (keyed by image path) - for fast thumbnail generation
-        # Stores (rgb_array, timestamp) tuples, expires after 1800 seconds
-        self.image_cache: Dict[str, Tuple[np.ndarray, float]] = {}
+        # Image cache (keyed by image path) — stores (rgb_array, timestamp)
+        self.image_cache: OrderedDict[str, Tuple[np.ndarray, float]] = OrderedDict()
         self.image_cache_ttl = 1800  # 30 minutes
+
+        # Debounced save state
+        self._save_pending = False
+        self._save_lock = asyncio.Lock()
+        self._save_task: Optional[asyncio.Task] = None
+
+    @staticmethod
+    def _lru_put(cache: OrderedDict, key, value, max_size: int):
+        """Insert into an OrderedDict with LRU eviction."""
+        if key in cache:
+            cache.move_to_end(key)
+        cache[key] = value
+        while len(cache) > max_size:
+            cache.popitem(last=False)
+
+    async def _schedule_save(self):
+        """Debounce database saves — coalesces rapid confirm/ignore calls."""
+        async with self._save_lock:
+            if self._save_pending:
+                return  # Already scheduled
+            self._save_pending = True
+
+        async def _do_save():
+            await asyncio.sleep(0.5)  # 500 ms debounce
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(
+                _executor,
+                save_database,
+                self.known_faces,
+                self.ignored_faces,
+                self.hard_negatives,
+                self.processed_files,
+            )
+            async with self._save_lock:
+                self._save_pending = False
+            logger.debug("[DetectionService] Debounced save completed")
+
+        self._save_task = asyncio.create_task(_do_save())
+
+    async def _flush_save(self):
+        """Force immediate save (used for final operations like mark_review_complete)."""
+        # Cancel pending debounced save if any
+        if self._save_task and not self._save_task.done():
+            self._save_task.cancel()
+            try:
+                await self._save_task
+            except asyncio.CancelledError:
+                pass
+        async with self._save_lock:
+            self._save_pending = False
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            _executor,
+            save_database,
+            self.known_faces,
+            self.ignored_faces,
+            self.hard_negatives,
+            self.processed_files,
+        )
 
     def reload_database(self) -> Dict[str, Any]:
         """
@@ -124,7 +195,7 @@ class DetectionService:
             img = Image.open(image_path)
             return np.array(img.convert('RGB'))
 
-    def _detect_and_match_faces(self, rgb: np.ndarray, max_dimension: int = 4500) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    def _detect_and_match_faces(self, rgb: np.ndarray, max_dimension: int = 4500, file_hash: Optional[str] = None) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         """Detect faces and match against database. Returns (faces, detection_meta)."""
         import cv2
 
@@ -193,8 +264,8 @@ class DetectionService:
             full_encoding_hash = hashlib.sha1(encoding.tobytes()).hexdigest()
             face_id = f"face_{i}_{full_encoding_hash[:16]}"
 
-            # Cache encoding for later confirm/ignore operations
-            self.encoding_cache[face_id] = (encoding, bbox)
+            # Cache encoding for later confirm/ignore operations (includes file_hash to avoid rehashing)
+            self._lru_put(self.encoding_cache, face_id, (encoding, bbox, file_hash), MAX_ENCODING_CACHE)
 
             # Calculate ignore confidence
             ignore_confidence = None
@@ -397,19 +468,23 @@ class DetectionService:
         if not path.exists():
             raise FileNotFoundError(f"Image not found: {image_path}")
 
-        # Check cache
-        file_hash = self._get_file_hash(path)
+        # Check cache (hash computed in thread pool to avoid blocking event loop)
+        loop = asyncio.get_event_loop()
+        file_hash = await loop.run_in_executor(_executor, self._get_file_hash, path)
         if not force_reprocess and file_hash in self.cache:
             logger.info(f"[DetectionService] Using cached result for: {image_path}")
+            self.cache.move_to_end(file_hash)
             cached_result = self.cache[file_hash]
             cached_result["cached"] = True
             return cached_result
 
-        # Load image
-        rgb = self._load_image(path)
+        # Load image in thread pool
+        rgb = await loop.run_in_executor(_executor, self._load_image, path)
 
-        # Detect and match faces
-        faces, detection_meta = self._detect_and_match_faces(rgb)
+        # Detect and match faces in thread pool
+        faces, detection_meta = await loop.run_in_executor(
+            _executor, self._detect_and_match_faces, rgb, 4500, file_hash
+        )
 
         # Build result
         processing_time = (time.time() - start_time) * 1000  # milliseconds
@@ -417,12 +492,12 @@ class DetectionService:
             "faces": faces,
             "processing_time_ms": processing_time,
             "cached": False,
-            "file_hash": file_hash,  # Include hash for reuse in mark-review-complete
-            "detection_meta": detection_meta  # Include scale info for statistics
+            "file_hash": file_hash,
+            "detection_meta": detection_meta
         }
 
-        # Cache result
-        self.cache[file_hash] = result
+        # Cache result with LRU eviction
+        self._lru_put(self.cache, file_hash, result, MAX_DETECTION_CACHE)
         logger.info(f"[DetectionService] Detected {len(faces)} faces in {processing_time:.1f}ms")
 
         return result
@@ -440,29 +515,27 @@ class DetectionService:
             JPEG thumbnail bytes
         """
         import io
-        import time
 
         # Check image cache first
         path = Path(image_path)
         cache_key = str(path)
         current_time = time.time()
+        loop = asyncio.get_event_loop()
 
         if cache_key in self.image_cache:
             rgb, timestamp = self.image_cache[cache_key]
-            # Check if cache entry is still valid
             if current_time - timestamp < self.image_cache_ttl:
+                self.image_cache.move_to_end(cache_key)
                 logger.debug(f"[DetectionService] Using cached image for thumbnail: {path.name}")
             else:
-                # Cache expired, remove it
                 logger.debug(f"[DetectionService] Cache expired for: {path.name}")
                 del self.image_cache[cache_key]
-                rgb = self._load_image(path)
-                self.image_cache[cache_key] = (rgb, current_time)
+                rgb = await loop.run_in_executor(_executor, self._load_image, path)
+                self._lru_put(self.image_cache, cache_key, (rgb, current_time), MAX_IMAGE_CACHE)
         else:
-            # Load image and cache it
             logger.debug(f"[DetectionService] Loading and caching image for thumbnail: {path.name}")
-            rgb = self._load_image(path)
-            self.image_cache[cache_key] = (rgb, current_time)
+            rgb = await loop.run_in_executor(_executor, self._load_image, path)
+            self._lru_put(self.image_cache, cache_key, (rgb, current_time), MAX_IMAGE_CACHE)
 
         # Extract bounding box coordinates
         x = bounding_box['x']
@@ -487,7 +560,6 @@ class DetectionService:
         dst_y2 = dst_y1 + (src_y2 - src_y1)
 
         # Create black canvas of requested size
-        import numpy as np
         cropped = np.zeros((height, width, 3), dtype=np.uint8)
 
         # Copy the valid region if there's any overlap
@@ -534,8 +606,9 @@ class DetectionService:
         if face_id.startswith("manual_"):
             logger.info(f"[DetectionService] Manual face confirmed: {person_name}")
 
+            loop = asyncio.get_event_loop()
             path = Path(image_path)
-            file_hash = get_file_hash(path) if path.exists() else None
+            file_hash = await loop.run_in_executor(_executor, get_file_hash, path) if path.exists() else None
             backend_info = self.backend.get_model_info()
 
             entry = {
@@ -554,7 +627,7 @@ class DetectionService:
                 self.known_faces[person_name] = []
             self.known_faces[person_name].append(entry)
 
-            save_database(self.known_faces, self.ignored_faces, self.hard_negatives, self.processed_files)
+            await self._schedule_save()
             logger.info(f"[DetectionService] Saved manual face for {person_name} (total: {len(self.known_faces[person_name])})")
 
             return {
@@ -563,15 +636,20 @@ class DetectionService:
                 "encodings_count": len(self.known_faces[person_name])
             }
 
-        # Get encoding from cache
+        # Get encoding + cached file_hash from cache
         if face_id not in self.encoding_cache:
             raise ValueError(f"Face ID not found in cache: {face_id}. Detection may have expired.")
 
-        encoding, bbox = self.encoding_cache[face_id]
+        encoding, bbox, cached_hash = self.encoding_cache[face_id]
+        self.encoding_cache.move_to_end(face_id)
 
-        # Get file hash
-        path = Path(image_path)
-        file_hash = get_file_hash(path) if path.exists() else None
+        # Use cached hash if available, otherwise compute
+        if cached_hash:
+            file_hash = cached_hash
+        else:
+            loop = asyncio.get_event_loop()
+            path = Path(image_path)
+            file_hash = await loop.run_in_executor(_executor, get_file_hash, path) if path.exists() else None
 
         # Compute encoding hash
         encoding_hash = hashlib.sha1(encoding.tobytes()).hexdigest()
@@ -612,7 +690,7 @@ class DetectionService:
             self.hard_negatives[suggested_name].append(hard_neg_entry)
             logger.info(f"[DetectionService] Added hard negative for {suggested_name} (corrected to {person_name})")
 
-        save_database(self.known_faces, self.ignored_faces, self.hard_negatives, self.processed_files)
+        await self._schedule_save()
 
         logger.info(f"[DetectionService] Saved encoding for {person_name} (total: {len(self.known_faces[person_name])})")
 
@@ -636,23 +714,27 @@ class DetectionService:
         logger.info(f"[DetectionService] Ignoring face {face_id}")
 
         # Handle manual faces (no encoding to add to ignored list)
-        # Manual faces are included in mark_review_complete for rename functionality
         if face_id.startswith("manual_"):
             logger.info(f"[DetectionService] Manual face ignored (no encoding to save)")
             return {
                 "status": "success",
-                "ignored_count": len(self.ignored_faces)  # Return current count unchanged
+                "ignored_count": len(self.ignored_faces)
             }
 
-        # Get encoding from cache
+        # Get encoding + cached file_hash from cache
         if face_id not in self.encoding_cache:
             raise ValueError(f"Face ID not found in cache: {face_id}. Detection may have expired.")
 
-        encoding, bbox = self.encoding_cache[face_id]
+        encoding, bbox, cached_hash = self.encoding_cache[face_id]
+        self.encoding_cache.move_to_end(face_id)
 
-        # Get file hash
-        path = Path(image_path)
-        file_hash = get_file_hash(path) if path.exists() else None
+        # Use cached hash if available, otherwise compute
+        if cached_hash:
+            file_hash = cached_hash
+        else:
+            loop = asyncio.get_event_loop()
+            path = Path(image_path)
+            file_hash = await loop.run_in_executor(_executor, get_file_hash, path) if path.exists() else None
 
         # Compute encoding hash
         encoding_hash = hashlib.sha1(encoding.tobytes()).hexdigest()
@@ -675,8 +757,8 @@ class DetectionService:
         # Add to ignored_faces
         self.ignored_faces.append(entry)
 
-        # Save database
-        save_database(self.known_faces, self.ignored_faces, self.hard_negatives, self.processed_files)
+        # Debounced save
+        await self._schedule_save()
 
         logger.info(f"[DetectionService] Added face to ignored list (total: {len(self.ignored_faces)})")
 
@@ -708,10 +790,11 @@ class DetectionService:
         """
         logger.info(f"[DetectionService] Marking review complete for {image_path}")
 
-        # Use provided hash or compute if needed
+        # Use provided hash or compute in thread pool
         if file_hash is None:
+            loop = asyncio.get_event_loop()
             path = Path(image_path)
-            file_hash = get_file_hash(path) if path.exists() else None
+            file_hash = await loop.run_in_executor(_executor, get_file_hash, path) if path.exists() else None
         else:
             logger.debug(f"[DetectionService] Using provided file_hash: {file_hash[:8]}...")
 
@@ -752,15 +835,19 @@ class DetectionService:
             "time_seconds": round(processing_time_ms / 1000, 3),
         }]
 
-        # Log to attempt_stats.jsonl
-        log_attempt_stats(
-            image_path=image_path,
-            attempts=attempts,
-            used_attempt_idx=0,
-            base_dir=BASE_DIR,
-            review_results=["ok"],
-            labels_per_attempt=[labels],
-            file_hash=file_hash
+        # Log to attempt_stats.jsonl (blocking I/O — run in thread pool)
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            _executor,
+            lambda: log_attempt_stats(
+                image_path=image_path,
+                attempts=attempts,
+                used_attempt_idx=0,
+                base_dir=BASE_DIR,
+                review_results=["ok"],
+                labels_per_attempt=[labels],
+                file_hash=file_hash
+            )
         )
 
         logger.info(f"[DetectionService] Logged {len(labels)} face labels to attempt_stats.jsonl")
@@ -770,7 +857,7 @@ class DetectionService:
         entry = {"name": file_name, "hash": file_hash}
         if entry not in self.processed_files:
             self.processed_files.append(entry)
-            save_database(self.known_faces, self.ignored_faces, self.hard_negatives, self.processed_files)
+            await self._flush_save()  # Immediate save — review is finalized
             logger.info(f"[DetectionService] Added {file_name} to processed_files")
 
         return {

--- a/backend/api/services/detection_service.py
+++ b/backend/api/services/detection_service.py
@@ -767,6 +767,149 @@ class DetectionService:
             "ignored_count": len(self.ignored_faces)
         }
 
+    def _confirm_identity_nosave(
+        self,
+        face_id: str,
+        person_name: str,
+        image_path: str,
+        suggested_name: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """In-memory confirm without saving to disk. Returns result dict."""
+        if face_id.startswith("manual_"):
+            backend_info = self.backend.get_model_info()
+            entry = {
+                "encoding": None,
+                "file": str(image_path),
+                "hash": None,
+                "backend": self.backend.backend_name,
+                "backend_version": backend_info.get("version", "unknown"),
+                "created_at": datetime.now().isoformat(),
+                "encoding_hash": None,
+                "bounding_box": None,
+                "is_manual": True
+            }
+            if person_name not in self.known_faces:
+                self.known_faces[person_name] = []
+            self.known_faces[person_name].append(entry)
+            return {"status": "success", "person_name": person_name,
+                    "encodings_count": len(self.known_faces[person_name])}
+
+        if face_id not in self.encoding_cache:
+            raise ValueError(f"Face ID not found in cache: {face_id}. Detection may have expired.")
+
+        encoding, bbox, cached_hash = self.encoding_cache[face_id]
+        self.encoding_cache.move_to_end(face_id)
+        file_hash = cached_hash
+        encoding_hash = hashlib.sha1(encoding.tobytes()).hexdigest()
+        backend_info = self.backend.get_model_info()
+
+        entry = {
+            "encoding": encoding,
+            "file": str(image_path),
+            "hash": file_hash,
+            "backend": self.backend.backend_name,
+            "backend_version": backend_info.get("version", "unknown"),
+            "created_at": datetime.now().isoformat(),
+            "encoding_hash": encoding_hash,
+            "bounding_box": bbox
+        }
+
+        if person_name not in self.known_faces:
+            self.known_faces[person_name] = []
+        self.known_faces[person_name].append(entry)
+
+        if suggested_name and suggested_name != person_name:
+            if suggested_name not in self.hard_negatives:
+                self.hard_negatives[suggested_name] = []
+            hard_neg_entry = {
+                "encoding": encoding,
+                "file": str(image_path),
+                "hash": file_hash,
+                "backend": self.backend.backend_name,
+                "backend_version": backend_info.get("version", "unknown"),
+                "created_at": datetime.now().isoformat(),
+                "encoding_hash": encoding_hash
+            }
+            self.hard_negatives[suggested_name].append(hard_neg_entry)
+
+        return {"status": "success", "person_name": person_name,
+                "encodings_count": len(self.known_faces[person_name])}
+
+    def _ignore_face_nosave(self, face_id: str, image_path: str) -> Dict[str, Any]:
+        """In-memory ignore without saving to disk. Returns result dict."""
+        if face_id.startswith("manual_"):
+            return {"status": "success", "ignored_count": len(self.ignored_faces)}
+
+        if face_id not in self.encoding_cache:
+            raise ValueError(f"Face ID not found in cache: {face_id}. Detection may have expired.")
+
+        encoding, bbox, cached_hash = self.encoding_cache[face_id]
+        self.encoding_cache.move_to_end(face_id)
+        file_hash = cached_hash
+        encoding_hash = hashlib.sha1(encoding.tobytes()).hexdigest()
+        backend_info = self.backend.get_model_info()
+
+        entry = {
+            "encoding": encoding,
+            "file": str(image_path),
+            "hash": file_hash,
+            "backend": self.backend.backend_name,
+            "backend_version": backend_info.get("version", "unknown"),
+            "created_at": datetime.now().isoformat(),
+            "encoding_hash": encoding_hash,
+            "bounding_box": bbox
+        }
+        self.ignored_faces.append(entry)
+        return {"status": "success", "ignored_count": len(self.ignored_faces)}
+
+    async def batch_confirm(
+        self,
+        confirmations: List[Dict[str, Any]],
+        ignores: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """
+        Batch confirm/ignore faces with a single database save.
+
+        Args:
+            confirmations: List of {face_id, person_name, image_path, suggested_name?}
+            ignores: List of {face_id, image_path}
+
+        Returns:
+            Summary with confirmed_count, ignored_count, errors
+        """
+        confirmed = 0
+        ignored = 0
+        errors = []
+
+        for c in confirmations:
+            try:
+                self._confirm_identity_nosave(
+                    c["face_id"], c["person_name"], c["image_path"],
+                    c.get("suggested_name")
+                )
+                confirmed += 1
+            except Exception as e:
+                errors.append({"face_id": c["face_id"], "error": str(e)})
+
+        for ig in ignores:
+            try:
+                self._ignore_face_nosave(ig["face_id"], ig["image_path"])
+                ignored += 1
+            except Exception as e:
+                errors.append({"face_id": ig["face_id"], "error": str(e)})
+
+        # Single save for entire batch
+        await self._flush_save()
+
+        logger.info(f"[DetectionService] Batch: confirmed={confirmed}, ignored={ignored}, errors={len(errors)}")
+
+        return {
+            "status": "success",
+            "confirmed_count": confirmed,
+            "ignored_count": ignored,
+            "errors": errors
+        }
+
     async def mark_review_complete(
         self,
         image_path: str,

--- a/backend/api/services/rename_service.py
+++ b/backend/api/services/rename_service.py
@@ -646,9 +646,11 @@ def collect_persons_for_files(
 
         if review_persons:
             persons = list(review_persons)
-            for name in encoding_persons:
-                if name not in persons:
-                    persons.append(name)
+            merged = [n for n in encoding_persons if n not in persons]
+            if merged:
+                logger.info(f"[Rename] Merged {merged} from encodings for {fname}")
+            for name in merged:
+                persons.append(name)
         else:
             persons = encoding_persons
 

--- a/backend/api/services/statistics_service.py
+++ b/backend/api/services/statistics_service.py
@@ -35,7 +35,7 @@ class StatisticsService:
         # Cache for expensive calculations
         self.cache: Dict[str, Any] = {}
         self.cache_timestamps: Dict[str, float] = {}
-        self.cache_ttl = 2.0  # 2 second cache TTL
+        self.cache_ttl = 30.0  # 30 second cache TTL
 
     def _is_cache_valid(self, key: str) -> bool:
         """Check if cache entry is still valid"""
@@ -53,6 +53,12 @@ class StatisticsService:
         """Set cached value with timestamp"""
         self.cache[key] = value
         self.cache_timestamps[key] = time.time()
+
+    def invalidate_cache(self):
+        """Invalidate all cached data. Call after review completion."""
+        self.cache.clear()
+        self.cache_timestamps.clear()
+        logger.info("[StatisticsService] Cache invalidated")
 
     def count_faces_per_name(self, known_faces: Dict = None) -> Dict[str, int]:
         """Count number of face encodings per person"""
@@ -205,7 +211,7 @@ class StatisticsService:
             "ignored_fraction": round(ignored_frac, 3),
         }
 
-    async def get_recent_images(self, n: int = 3) -> List[Dict[str, Any]]:
+    async def get_recent_images(self, n: int = 3, stats: List[Dict] = None) -> List[Dict[str, Any]]:
         """
         Get most recent processed images with names
 
@@ -215,7 +221,8 @@ class StatisticsService:
         - person_names: List of person names in image
         - source: Where the review came from ('ansikten' or 'cli')
         """
-        stats = load_attempt_log(all_files=False)
+        if stats is None:
+            stats = load_attempt_log(all_files=False)
 
         # Sort by timestamp, get last n
         last = sorted(stats, key=lambda x: x.get("timestamp", ""), reverse=True)[:n]
@@ -404,7 +411,7 @@ class StatisticsService:
 
         attempt_stats = await self.get_attempt_stats(stats)
         top_faces = await self.get_top_faces(stats, known_faces)
-        recent_images = await self.get_recent_images(n=3)
+        recent_images = await self.get_recent_images(n=3, stats=stats)
         recent_logs = await self.get_recent_logs(n=3)
 
         summary = {

--- a/backend/faceid_db.py
+++ b/backend/faceid_db.py
@@ -4,6 +4,7 @@ import json
 import logging
 import pickle
 import re
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from io import BufferedReader
 from pathlib import Path
@@ -240,6 +241,38 @@ def load_database() -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any
     return known_faces, ignored_faces, hard_negatives, processed_files
 
 
+def _atomic_pickle_write(data, target_path):
+    """Write pickle file atomically with exclusive lock."""
+    temp_path = target_path.with_suffix('.tmp')
+    try:
+        with open(temp_path, "wb") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            pickle.dump(data, f)
+        temp_path.replace(target_path)
+    except Exception as e:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise e
+
+
+def _atomic_jsonl_write(entries, target_path):
+    """Write JSONL file atomically with exclusive lock."""
+    temp_path = target_path.with_suffix('.tmp')
+    try:
+        with open(temp_path, "w", encoding="utf-8") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            for entry in entries:
+                if isinstance(entry, dict):
+                    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                else:
+                    f.write(json.dumps({"name": entry, "hash": None}, ensure_ascii=False) + "\n")
+        temp_path.replace(target_path)
+    except Exception as e:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise e
+
+
 def save_database(
     known_faces: dict[str, list[dict[str, Any]]],
     ignored_faces: list[dict[str, Any]],
@@ -251,50 +284,21 @@ def save_database(
 
     Uses atomic write pattern (write to temp file, then rename) to ensure
     database files are never left in a partially-written state.
+    Writes the four files in parallel for better throughput.
     """
     BASE_DIR.mkdir(parents=True, exist_ok=True)
 
-    def atomic_pickle_write(data, target_path):
-        """Write pickle file atomically with exclusive lock."""
-        temp_path = target_path.with_suffix('.tmp')
-        try:
-            with open(temp_path, "wb") as f:
-                # Acquire exclusive lock to prevent concurrent writes
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                pickle.dump(data, f)
-                # Lock released automatically on close
-            # Atomic rename - replaces target atomically
-            temp_path.replace(target_path)
-        except Exception as e:
-            # Clean up temp file on error
-            if temp_path.exists():
-                temp_path.unlink()
-            raise e
-
-    def atomic_jsonl_write(entries, target_path):
-        """Write JSONL file atomically with exclusive lock."""
-        temp_path = target_path.with_suffix('.tmp')
-        try:
-            with open(temp_path, "w", encoding="utf-8") as f:
-                # Acquire exclusive lock
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                for entry in entries:
-                    if isinstance(entry, dict):
-                        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-                    else:
-                        f.write(json.dumps({"name": entry, "hash": None}, ensure_ascii=False) + "\n")
-            # Atomic rename
-            temp_path.replace(target_path)
-        except Exception as e:
-            if temp_path.exists():
-                temp_path.unlink()
-            raise e
-
-    # Write all database files atomically
-    atomic_pickle_write(known_faces, ENCODING_PATH)
-    atomic_pickle_write(ignored_faces, IGNORED_PATH)
-    atomic_pickle_write(hard_negatives, HARDNEG_PATH)
-    atomic_jsonl_write(processed_files, PROCESSED_PATH)
+    # Write all database files in parallel
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [
+            pool.submit(_atomic_pickle_write, known_faces, ENCODING_PATH),
+            pool.submit(_atomic_pickle_write, ignored_faces, IGNORED_PATH),
+            pool.submit(_atomic_pickle_write, hard_negatives, HARDNEG_PATH),
+            pool.submit(_atomic_jsonl_write, processed_files, PROCESSED_PATH),
+        ]
+        # Raise first exception if any write failed
+        for f in futures:
+            f.result()
 
 
 def load_attempt_log(all_files: bool = False) -> list[dict[str, Any]]:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ansikten-backend"
+version = "1.0.0"
+description = "Face recognition backend for event photography"
+requires-python = ">=3.11"
+dependencies = [
+    "face_recognition",
+    "numpy",
+    "pillow",
+    "opencv-python",
+    "rawpy",
+    "prompt_toolkit",
+    "rich",
+    "pyxdg",
+    "matplotlib",
+    # InsightFace backend
+    "insightface>=0.7",
+    "onnxruntime>=1.15",
+    # FastAPI server
+    "fastapi>=0.100.0",
+    "uvicorn[standard]>=0.23.0",
+    "websockets>=11.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
+]
+build = [
+    "pyinstaller>=6.0",
+]
+
+[tool.setuptools]
+py-modules = []
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+pythonpath = ["."]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-testpaths = tests
-python_files = test_*.py
-python_classes = Test*
-python_functions = test_*
-pythonpath = .

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,26 +1,5 @@
-face_recognition
-numpy
-pillow
-opencv-python
-rawpy
-prompt_toolkit
-rich
-pyxdg
-matplotlib
-
-# Optional: for InsightFace backend
-insightface>=0.7
-onnxruntime>=1.15
-
-# FastAPI backend server
-fastapi>=0.100.0
-uvicorn[standard]>=0.23.0
-websockets>=11.0
-
-# Development only (for building distributable app)
-# pyinstaller>=6.0
-
-# Testing
-pytest>=8.0
-pytest-asyncio>=0.23
-httpx>=0.27
+# Dependencies are defined in pyproject.toml.
+# This file exists for backwards compatibility.
+#
+# Install:  pip install -e .
+# With dev: pip install -e ".[dev]"

--- a/docs/dev/building.md
+++ b/docs/dev/building.md
@@ -54,12 +54,12 @@ sudo apt-get install -y cmake build-essential
 cd backend
 
 # Create virtual environment
-python3 -m venv venv
-source venv/bin/activate  # Linux/macOS
-# or: venv\Scripts\activate  # Windows
+python3 -m venv .venv
+source .venv/bin/activate  # Linux/macOS
+# or: .venv\Scripts\activate  # Windows
 
-# Install dependencies
-pip install -r requirements.txt
+# Install dependencies (from pyproject.toml)
+pip install -e ".[dev]"
 ```
 
 ### Frontend

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -183,9 +183,9 @@ function processImage(path) {
 
 ```bash
 cd backend
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
 
 # Run CLI
 ./hitta_ansikten.py --help

--- a/docs/dev/onboarding.md
+++ b/docs/dev/onboarding.md
@@ -60,11 +60,11 @@ cd ansikten
 cd backend
 
 # Create virtual environment
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 
-# Install dependencies
-pip install -r requirements.txt
+# Install dependencies (from pyproject.toml)
+pip install -e ".[dev]"
 ```
 
 **Troubleshooting:**

--- a/docs/dev/release-guide.md
+++ b/docs/dev/release-guide.md
@@ -41,9 +41,15 @@ npm run build:workspace
 npx electron .
 ```
 
-### 2. Uppdatera changelog (valfritt)
+### 2. Roadmap -> Changelog (obligatoriskt)
 
-Om du har en CHANGELOG.md, uppdatera den med ändringar sedan senaste release.
+Arbetsprincip för planering och releaseförberedelse:
+
+1. Planera framtida arbete i `docs/dev/roadmap.md`
+2. När arbete är klart inför release, flytta relevanta punkter från roadmap till `CHANGELOG.md`
+3. Finslipa `CHANGELOG.md` så den beskriver ändringarna sedan senaste tag
+
+Det här håller roadmap framåtblickande och changelog release-fokuserad.
 
 ### 3. Skapa och pusha tag
 
@@ -95,9 +101,9 @@ GitHub Actions genererar följande filer:
 
 **Python-beroenden:**
 ```bash
-# Kontrollera att requirements.txt är uppdaterad
+# Kontrollera att pyproject.toml är uppdaterad
 cd backend
-pip install -r requirements.txt
+pip install -e ".[build]"
 pyinstaller ansikten-backend.spec
 ```
 
@@ -177,3 +183,4 @@ Workflow-filen: `.github/workflows/release.yml`
 
 - [Building](building.md) - Detaljerad byggdokumentation
 - [Contributing](contributing.md) - Bidragsguide
+- [Roadmap](roadmap.md) - Planerad utveckling framåt

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -1,0 +1,106 @@
+# Roadmap
+
+Planned work for performance-focused release `v1.2.0`.
+
+---
+
+## Scope for v1.2.0
+
+This release focuses on end-to-end performance and efficiency improvements:
+
+- Backend request latency and event loop health
+- Database I/O efficiency during review flows
+- Frontend runtime overhead and responsiveness
+- Better scalability for larger face databases and longer sessions
+
+---
+
+## Sprint 1 - Foundation and largest latency gains
+
+### Goals
+
+- Remove major backend event-loop blocking
+- Reduce time-to-first-result for face detection
+- Establish baseline performance instrumentation
+
+### Planned work
+
+- Move heavy detection and thumbnail work off the async event loop (thread/process workers)
+- Add concurrency limits for expensive endpoints (`detect`, `thumbnail`, `preprocess`)
+- Reuse `file_hash` across flows to avoid repeated large-file hashing
+- Reduce aggressive frontend polling where event-driven updates are available
+
+### Deliverables
+
+- P95 latency for `/api/v1/detect-faces` improved by at least 30%
+- No noticeable UI freeze during concurrent operations
+- Baseline/perf dashboard for detection latency, thumbnail latency, CPU peaks
+
+### Risks
+
+- Worker pool saturation if concurrency limits are misconfigured
+
+---
+
+## Sprint 2 - I/O and data-flow efficiency
+
+### Goals
+
+- Minimize database write amplification
+- Improve save performance in review workflows
+- Reduce repeated heavy reads for statistics
+
+### Planned work
+
+- Add batch review-save endpoint (confirm + ignore in one request per image)
+- Persist database once per image review (not once per face)
+- Improve statistics caching strategy (longer TTL and incremental handling where possible)
+- Update frontend review flow to use batch submit
+- Ensure statistics refresh interval in UI controls actual fetch cadence
+
+### Deliverables
+
+- 60-90% fewer database writes during review sessions
+- P95 for review-save improved by at least 50%
+- Reduced disk I/O spikes during batch review
+
+### Risks
+
+- Batch error handling must clearly define partial-success behavior
+
+---
+
+## Sprint 3 - Scalability and sustained responsiveness
+
+### Goals
+
+- Improve matching performance as dataset size grows
+- Lower idle/runtime overhead in frontend
+- Maintain smooth UX in long sessions
+
+### Planned work
+
+- Optimize matching path with precompiled/indexed structures on database reload
+- Add cache invalidation strategy tied to database mutation/reload events
+- Replace log polling with event-driven updates in UI
+- Pause or throttle background refresh for hidden/inactive modules
+- Reduce unnecessary global listener rebinding
+
+### Deliverables
+
+- Detection throughput improved by at least 40% on large dataset benchmarks
+- Lower renderer idle CPU usage in steady-state operation
+- Stable responsiveness across long-running sessions
+
+### Risks
+
+- Cache invalidation logic must be exact to avoid stale match behavior
+
+---
+
+## Definition of Done (all sprints)
+
+- Performance measured before/after on the same dataset and scenarios
+- Regression tests added for changed critical endpoints/flows
+- Telemetry and logs verify p95 latency, error rate, and throughput
+- No functional regressions in review, preprocessing, or rename workflows

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -34,12 +34,12 @@ cd ansikten
 
 ```bash
 # Skapa virtuell miljö (rekommenderas)
-python -m venv venv
-source venv/bin/activate  # Linux/macOS
-# eller: venv\Scripts\activate  # Windows
+python3 -m venv .venv
+source .venv/bin/activate  # Linux/macOS
+# eller: .venv\Scripts\activate  # Windows
 
-# Installera beroenden
-pip install -r requirements.txt
+# Installera beroenden (från pyproject.toml)
+pip install -e "."
 ```
 
 #### Face Recognition Backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ansikten",
   "productName": "Ansikten",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Face detection and annotation tool for image review",
   "main": "main.js",
   "scripts": {

--- a/frontend/scripts/build-backend.js
+++ b/frontend/scripts/build-backend.js
@@ -58,7 +58,7 @@ function main() {
   } catch (err) {
     console.error('\nPyInstaller build failed.');
     console.error('Make sure you have activated your Python environment and installed dependencies:');
-    console.error('  pip install -r requirements.txt pyinstaller\n');
+    console.error('  pip install -e ".[build]"\n');
     process.exit(1);
   }
 

--- a/frontend/src/main/backend-service.js
+++ b/frontend/src/main/backend-service.js
@@ -88,12 +88,16 @@ class BackendService {
       // Development: Use system Python with uvicorn
       const backendDir = path.join(__dirname, '../../../backend');
 
-      // Try to find Python in common locations
+      // Try to find Python in common locations (convention-based)
+      const venvPython = process.platform === 'win32'
+        ? path.join(backendDir, '.venv', 'Scripts', 'python.exe')
+        : path.join(backendDir, '.venv', 'bin', 'python3');
+
       const pythonPaths = [
         process.env.ANSIKTEN_PYTHON,  // Custom path via env var
-        '/Users/krisniem/.local/share/miniforge3/envs/ansikten/bin/python3',  // Dev default
-        'python3',  // System Python
-        'python',   // Fallback
+        venvPython,                    // Project venv in backend/.venv
+        'python3',                     // System Python
+        'python',                      // Fallback
       ].filter(Boolean);
 
       const { execSync } = require('child_process');

--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -125,6 +125,16 @@ function parseCommandLineArgs(argv) {
   return result;
 }
 
+// Supported image extensions — filter out sidecars (xmp) and other non-image files
+const SUPPORTED_IMAGE_EXTENSIONS = new Set([
+  '.nef', '.cr2', '.arw', '.jpg', '.jpeg', '.png', '.tiff',
+]);
+
+function isSupportedImageFile(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return SUPPORTED_IMAGE_EXTENSIONS.has(ext);
+}
+
 // Expand globs and resolve paths
 async function expandFilePaths(patterns) {
   const files = [];
@@ -150,7 +160,7 @@ async function expandFilePaths(patterns) {
         for (const entry of entries) {
           if (regex.test(entry)) {
             const fullPath = path.join(dir, entry);
-            if (fs.statSync(fullPath).isFile()) {
+            if (fs.statSync(fullPath).isFile() && isSupportedImageFile(fullPath)) {
               files.push(fullPath);
             }
           }
@@ -162,12 +172,14 @@ async function expandFilePaths(patterns) {
         );
       }
     } else {
-      // Direct path - must be a file (not directory)
+      // Direct path - must be a supported image file (not directory or sidecar)
       const resolved = path.resolve(expandedPattern);
       try {
         const stat = fs.statSync(resolved);
-        if (stat.isFile()) {
+        if (stat.isFile() && isSupportedImageFile(resolved)) {
           files.push(resolved);
+        } else if (stat.isFile()) {
+          console.log(`[Main] Skipping unsupported file: ${resolved}`);
         } else if (stat.isDirectory()) {
           console.log(`[Main] Skipping directory: ${resolved}`);
         }
@@ -560,7 +572,9 @@ ipcMain.handle("expand-glob", async (event, pattern) => {
     if (glob) {
       const files = [];
       for await (const file of glob(expandedPattern)) {
-        files.push(file);
+        if (isSupportedImageFile(file)) {
+          files.push(file);
+        }
       }
       return files.sort();
     }
@@ -584,7 +598,7 @@ ipcMain.handle("expand-glob", async (event, pattern) => {
       .readdirSync(dir)
       .filter((f) => regex.test(f))
       .map((f) => path.join(dir, f))
-      .filter((f) => fs.statSync(f).isFile())
+      .filter((f) => fs.statSync(f).isFile() && isSupportedImageFile(f))
       .sort();
 
     return files;

--- a/frontend/src/renderer/components/FileQueueModule.css
+++ b/frontend/src/renderer/components/FileQueueModule.css
@@ -163,6 +163,51 @@
   opacity: 1;
 }
 
+/* Filter bar */
+.file-queue-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.file-queue-filter-bar .filter-icon {
+  color: var(--text-tertiary);
+  font-size: var(--font-sm);
+  font-family: monospace;
+  flex-shrink: 0;
+}
+
+.file-queue-filter-bar .filter-input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-size: var(--font-sm);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.file-queue-filter-bar .filter-input:focus {
+  border-color: var(--accent-primary);
+}
+
+.file-queue-filter-bar .filter-count {
+  color: var(--text-tertiary);
+  font-size: var(--font-xs);
+  flex-shrink: 0;
+}
+
+.file-queue-filter-bar .filter-close {
+  flex-shrink: 0;
+  padding: 2px;
+}
+
 /* Status icons */
 .status-icon {
   flex-shrink: 0;

--- a/frontend/src/renderer/components/FileQueueModule.css
+++ b/frontend/src/renderer/components/FileQueueModule.css
@@ -125,6 +125,11 @@
   color: var(--text-tertiary);
 }
 
+.file-item.focused {
+  background: var(--bg-hover);
+  border-color: var(--border-primary);
+}
+
 .file-item.selected {
   background: var(--accent-primary-alpha-20);
   border-color: var(--accent-primary);

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -220,7 +220,8 @@ export function FileQueueModule({ node }) {
   const [processedFilesLoaded, setProcessedFilesLoaded] = useState(false);
   const [preprocessingStatus, setPreprocessingStatus] = useState({});
   const [preprocessingPaused, setPreprocessingPaused] = useState(false);
-  const [selectedFiles, setSelectedFiles] = useState(new Set()); // Selected file IDs
+  const [selectedFiles, setSelectedFiles] = useState(new Set()); // Checkbox-selected file IDs
+  const [focusedIndex, setFocusedIndex] = useState(-1); // Clicked-on item (visual highlight only)
 
   // Rename state
   const [showPreviewNames, setShowPreviewNames] = useState(false);
@@ -1246,9 +1247,9 @@ export function FileQueueModule({ node }) {
       return;
     }
 
-    // Single click: Select the file (clear others, select this one)
+    // Single click: Focus the item (visual highlight only, no checkbox)
     lastSelectedIndexRef.current = index;
-    setSelectedFiles(new Set([item.id]));
+    setFocusedIndex(index);
   }, [queue, toggleFileSelection]);
 
   // Handle double-click to load file
@@ -1935,6 +1936,7 @@ export function FileQueueModule({ node }) {
               item={item}
               index={originalIndex}
               isActive={originalIndex === currentIndex}
+              isFocused={originalIndex === focusedIndex}
               isSelected={selectedFiles.has(item.id)}
               onClick={(e) => handleItemClick(originalIndex, e)}
               onDoubleClick={() => handleItemDoubleClick(originalIndex)}
@@ -2033,7 +2035,7 @@ export function FileQueueModule({ node }) {
 /**
  * FileQueueItem Component
  */
-function FileQueueItem({ item, index, isActive, isSelected, onClick, onDoubleClick, onToggleSelect, onRemove, onForceReprocess, fixMode, preprocessingStatus, showPreview, previewInfo }) {
+function FileQueueItem({ item, index, isActive, isFocused, isSelected, onClick, onDoubleClick, onToggleSelect, onRemove, onForceReprocess, fixMode, preprocessingStatus, showPreview, previewInfo }) {
   const [showTooltip, setShowTooltip] = useState(false);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const [namesDisplay, setNamesDisplay] = useState('');
@@ -2226,7 +2228,7 @@ function FileQueueItem({ item, index, isActive, isSelected, onClick, onDoubleCli
   return (
     <div
       ref={itemRef}
-      className={`file-item ${item.status} ${isActive ? 'active' : ''} ${isSelected ? 'selected' : ''} ${item.isAlreadyProcessed ? 'already-processed' : ''} ${shouldShowPreview ? 'with-preview' : ''}`}
+      className={`file-item ${item.status} ${isActive ? 'active' : ''} ${isFocused ? 'focused' : ''} ${isSelected ? 'selected' : ''} ${item.isAlreadyProcessed ? 'already-processed' : ''} ${shouldShowPreview ? 'with-preview' : ''}`}
       onClick={onClick}
       onDoubleClick={onDoubleClick}
       onMouseEnter={handleMouseEnter}

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -253,6 +253,9 @@ export function FileQueueModule({ node }) {
   const processedFilesRef = useRef(new Set());
   processedFilesRef.current = processedFiles;
 
+  // Queued manual load: stores index to load once processedFiles are ready
+  const pendingManualLoadRef = useRef(-1);
+
   // Get preprocessing manager (singleton)
   const preprocessingManager = useRef(null);
   if (!preprocessingManager.current) {
@@ -321,6 +324,17 @@ export function FileQueueModule({ node }) {
       preprocessingManager.current.setHashChecker((hash) => processedHashesRef.current.has(hash));
     }
   }, [processedFilesLoaded]);
+
+  // Execute queued manual load once processed files are ready
+  useEffect(() => {
+    if (processedFilesLoaded && pendingManualLoadRef.current >= 0) {
+      const idx = pendingManualLoadRef.current;
+      pendingManualLoadRef.current = -1;
+      debug('FileQueue', 'Executing queued manual load at index', idx);
+      loadFileRef.current?.(idx);
+    }
+  }, [processedFilesLoaded]);
+
   const statsFetchedRef = useRef(new Set());
   useEffect(() => {
     if (!processedFilesLoaded || processedFiles.size === 0) return;
@@ -1079,7 +1093,9 @@ export function FileQueueModule({ node }) {
     }
 
     if (!processedFilesLoadedRef.current) {
-      debug('FileQueue', 'loadFile: BLOCKED - processed files not loaded yet');
+      debug('FileQueue', 'loadFile: Queuing load - processed files not loaded yet');
+      pendingManualLoadRef.current = index;
+      showToast('Laddar fillista...', 'info', 2000);
       return;
     }
 
@@ -1110,15 +1126,9 @@ export function FileQueueModule({ node }) {
       return;
     }
 
-    const workspace = window.workspace;
-    let hasImageViewer = false;
-
-    if (workspace?.model) {
-      workspace.model.visitNodes(node => {
-        if (node.getComponent?.() === 'image-viewer') {
-          hasImageViewer = true;
-        }
-      });
+    // Ensure image viewer tab is visible/focused
+    if (window.workspace?.openModule) {
+      window.workspace.openModule('image-viewer');
     }
 
     if (fixModeRef.current && item.isAlreadyProcessed) {

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -223,6 +223,11 @@ export function FileQueueModule({ node }) {
   const [selectedFiles, setSelectedFiles] = useState(new Set()); // Checkbox-selected file IDs
   const [focusedIndex, setFocusedIndex] = useState(-1); // Clicked-on item (visual highlight only)
 
+  // Filter state
+  const [filterText, setFilterText] = useState('');
+  const [showFilter, setShowFilter] = useState(false);
+  const filterInputRef = useRef(null);
+
   // Rename state
   const [showPreviewNames, setShowPreviewNames] = useState(false);
   const [previewData, setPreviewData] = useState(null); // { path: { newName, status, persons } }
@@ -271,6 +276,7 @@ export function FileQueueModule({ node }) {
   const currentFileRef = useRef(null);
   const queueRef = useRef(queue); // Keep current queue in ref for callbacks
   queueRef.current = queue; // Sync on every render (not just in useEffect)
+  const visibleIdsRef = useRef(null); // Current filter-visible IDs for action scoping
   const fixModeRef = useRef(fixMode);
   fixModeRef.current = fixMode;
 
@@ -1015,13 +1021,18 @@ export function FileQueueModule({ node }) {
   const clearCompleted = useCallback(() => {
     const currentFixMode = fixModeRef.current;
     const currentQueue = queueRef.current;
+    const currentVisibleIds = visibleIdsRef.current;
+
+    const isDone = (item) => {
+      if (item.status === 'completed') return true;
+      if (!currentFixMode && item.isAlreadyProcessed) return true;
+      return false;
+    };
 
     // Check if active file will be removed
     const activeFile = currentQueue.find(item => item.filePath === currentFileRef.current);
-    const activeWillBeRemoved = activeFile && (
-      activeFile.status === 'completed' ||
-      (!currentFixMode && activeFile.isAlreadyProcessed)
-    );
+    const activeWillBeRemoved = activeFile && isDone(activeFile) &&
+      (!currentVisibleIds || currentVisibleIds.has(activeFile.id));
 
     if (activeWillBeRemoved) {
       emit('clear-image');
@@ -1029,9 +1040,10 @@ export function FileQueueModule({ node }) {
     }
 
     setQueue(prev => prev.filter(item => {
-      if (item.status === 'completed') return false;
-      if (!currentFixMode && item.isAlreadyProcessed) return false;
-      return true;
+      if (!isDone(item)) return true;
+      // When filter is active, only clear visible completed items
+      if (currentVisibleIds && !currentVisibleIds.has(item.id)) return true;
+      return false;
     }));
     setCurrentIndex(-1);
     setSelectedFiles(new Set());
@@ -1392,10 +1404,13 @@ export function FileQueueModule({ node }) {
     const currentFixMode = fixModeRef.current;
     const hasSelection = selectedFiles.size > 0;
 
+    const currentVisibleIds = visibleIdsRef.current;
     const eligiblePaths = queue
       .filter(q => {
         const isEligible = q.status === 'completed' || (!currentFixMode && q.isAlreadyProcessed);
-        return hasSelection ? (isEligible && selectedFiles.has(q.id)) : isEligible;
+        if (hasSelection) return isEligible && selectedFiles.has(q.id);
+        if (currentVisibleIds) return isEligible && currentVisibleIds.has(q.id);
+        return isEligible;
       })
       .map(q => q.filePath);
 
@@ -1747,12 +1762,53 @@ export function FileQueueModule({ node }) {
   }, [currentIndex]);
 
   // Keyboard shortcuts
+  const openFilter = useCallback(() => {
+    setShowFilter(true);
+    // Focus input on next tick (after React renders)
+    requestAnimationFrame(() => filterInputRef.current?.focus());
+  }, []);
+
+  const closeFilter = useCallback(() => {
+    setShowFilter(false);
+    setFilterText('');
+  }, []);
+
   useEffect(() => {
     const handleKeyDown = (e) => {
       // Skip keyboard handling when this tab is hidden in FlexLayout
       if (node && !node.isVisible()) return;
 
+      // Escape closes filter when filter input is focused
+      if (e.key === 'Escape' && showFilter) {
+        e.preventDefault();
+        closeFilter();
+        moduleRef.current?.focus();
+        return;
+      }
+
+      // Allow Cmd+F anywhere in the module to open filter
+      if (e.key === 'f' && (e.metaKey || e.ctrlKey)) {
+        const module = moduleRef.current;
+        const hasFocus = module && (
+          module === document.activeElement ||
+          module.contains(document.activeElement)
+        );
+        if (hasFocus) {
+          e.preventDefault();
+          e.stopPropagation();
+          openFilter();
+          return;
+        }
+      }
+
       if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+      // / (slash) - open filter (vim-style search)
+      if (e.key === '/') {
+        e.preventDefault();
+        openFilter();
+        return;
+      }
 
       // Cmd/Ctrl+A - select all files (prevent text selection)
       if (e.key === 'a' && (e.metaKey || e.ctrlKey)) {
@@ -1794,7 +1850,7 @@ export function FileQueueModule({ node }) {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [advanceToNext, currentIndex, loadFile, queue, selectedFiles.size, selectAll, deselectAll]);
+  }, [advanceToNext, currentIndex, loadFile, queue, selectedFiles.size, selectAll, deselectAll, showFilter, openFilter, closeFilter]);
 
   // Calculate stats
   // When fix-mode is OFF, already-processed files count as "done" (they're skipped)
@@ -1808,8 +1864,23 @@ export function FileQueueModule({ node }) {
   const hasSelection = selectedFiles.size > 0;
 
   const displayOrder = useMemo(() => {
-    return queue.map((item, i) => ({ item, originalIndex: i }));
-  }, [queue]);
+    const all = queue.map((item, i) => ({ item, originalIndex: i }));
+    if (!filterText) return all;
+
+    // Convert glob-style pattern to case-insensitive match:
+    // strip leading/trailing *, then substring match
+    const pattern = filterText.replace(/^\*+|\*+$/g, '').toLowerCase();
+    if (!pattern) return all;
+
+    return all.filter(({ item }) => item.fileName.toLowerCase().includes(pattern));
+  }, [queue, filterText]);
+
+  // Set of IDs currently visible after filtering — used for action scoping
+  const visibleIds = useMemo(() => {
+    if (!filterText) return null; // null = no filter active, all visible
+    return new Set(displayOrder.map(({ item }) => item.id));
+  }, [displayOrder, filterText]);
+  visibleIdsRef.current = visibleIds;
 
   const activeFile = currentIndex >= 0 ? queue[currentIndex] : null;
 
@@ -1910,6 +1981,45 @@ export function FileQueueModule({ node }) {
         )}
       </div>
 
+      {/* Filter bar */}
+      {showFilter && (
+        <div className="file-queue-filter-bar">
+          <span className="filter-icon">/</span>
+          <input
+            ref={filterInputRef}
+            type="text"
+            className="filter-input"
+            placeholder="Filter files..."
+            value={filterText}
+            onChange={(e) => setFilterText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                e.stopPropagation();
+                closeFilter();
+                moduleRef.current?.focus();
+              }
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                filterInputRef.current?.blur();
+              }
+            }}
+          />
+          {filterText && (
+            <span className="filter-count">
+              {displayOrder.length}/{queue.length}
+            </span>
+          )}
+          <button
+            className="btn-icon filter-close"
+            onClick={closeFilter}
+            title="Clear filter (Esc)"
+          >
+            <Icon name="close" size={12} />
+          </button>
+        </div>
+      )}
+
       {/* Current file status bar */}
       {activeFile && (
         <div className="current-file-bar" onClick={() => {
@@ -1991,16 +2101,24 @@ export function FileQueueModule({ node }) {
           <div className="file-queue-controls">
             {(() => {
               const hasSelection = selectedFiles.size > 0;
-              const renameCount = hasSelection
-                ? queue.filter(q => selectedFiles.has(q.id) && (q.status === 'completed' || (!fixMode && q.isAlreadyProcessed))).length
-                : completedCount;
-              const renameLabel = hasSelection ? `Rename (${renameCount} selected)` : `Rename (${renameCount})`;
+              const isEligible = q => q.status === 'completed' || (!fixMode && q.isAlreadyProcessed);
+              let renameCount, renameLabel;
+              if (hasSelection) {
+                renameCount = queue.filter(q => selectedFiles.has(q.id) && isEligible(q)).length;
+                renameLabel = `Rename (${renameCount} selected)`;
+              } else if (visibleIds) {
+                renameCount = queue.filter(q => visibleIds.has(q.id) && isEligible(q)).length;
+                renameLabel = `Rename (${renameCount} filtered)`;
+              } else {
+                renameCount = completedCount;
+                renameLabel = `Rename (${renameCount})`;
+              }
               return renameCount > 0 && (
                 <button
                   className="btn-secondary"
                   onClick={handleRename}
                   disabled={renameInProgress}
-                  title={hasSelection ? "Rename selected files" : "Rename files based on detected faces"}
+                  title={hasSelection ? "Rename selected files" : visibleIds ? "Rename filtered files" : "Rename files based on detected faces"}
                 >
                   {renameInProgress ? 'Renaming...' : renameLabel}
                 </button>

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -18,6 +18,7 @@ import { apiClient } from '../shared/api-client.js';
 import { getPreprocessingManager, PreprocessingStatus } from '../services/preprocessing/index.js';
 import { Icon } from './Icon.jsx';
 import { isFileEligible as isFileEligiblePure, findNextEligibleIndex } from './fileQueueEligibility.js';
+import { compileFilter } from './filterExpression.js';
 import { formatNamesToFit, measureTextWidth } from '../shared/nameFormatter.js';
 import './FileQueueModule.css';
 
@@ -1883,13 +1884,19 @@ export function FileQueueModule({ node }) {
     const all = queue.map((item, i) => ({ item, originalIndex: i }));
     if (!filterText) return all;
 
-    // Convert glob-style pattern to case-insensitive match:
-    // strip leading/trailing *, then substring match
-    const pattern = filterText.replace(/^\*+|\*+$/g, '').toLowerCase();
-    if (!pattern) return all;
+    const matcher = compileFilter(filterText);
 
-    return all.filter(({ item }) => item.fileName.toLowerCase().includes(pattern));
-  }, [queue, filterText]);
+    return all.filter(({ item }) => {
+      // Build searchable text: filename + detected/confirmed person names
+      const pp = preprocessingStatus[item.filePath];
+      const names = previewData?.[item.filePath]?.persons
+        || item.reviewedFaces?.map(f => f.personName).filter(Boolean)
+        || pp?.persons
+        || [];
+      const searchText = [item.fileName, ...names].join(' ');
+      return matcher(searchText);
+    });
+  }, [queue, filterText, preprocessingStatus, previewData]);
 
   // Set of IDs currently visible after filtering — used for action scoping
   const visibleIds = useMemo(() => {
@@ -2005,7 +2012,7 @@ export function FileQueueModule({ node }) {
             ref={filterInputRef}
             type="text"
             className="filter-input"
-            placeholder="Filter files..."
+            placeholder="Filter...  a|b = or  a&b = and"
             value={filterText}
             onChange={(e) => setFilterText(e.target.value)}
             onKeyDown={(e) => {

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -202,7 +202,7 @@ const SUPPORTED_EXTENSIONS = new Set(['nef', 'cr2', 'arw', 'jpg', 'jpeg', 'png',
 /**
  * FileQueueModule Component
  */
-export function FileQueueModule() {
+export function FileQueueModule({ node }) {
   const { api, isConnected } = useBackend();
   const emit = useEmitEvent();
   const globalShowToast = useToast();
@@ -1726,6 +1726,9 @@ export function FileQueueModule() {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e) => {
+      // Skip keyboard handling when this tab is hidden in FlexLayout
+      if (node && !node.isVisible()) return;
+
       if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
 
       // Cmd/Ctrl+A - select all files (prevent text selection)

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -196,7 +196,7 @@ const naturalSortCompare = (a, b) => {
  */
 const generateId = () => Math.random().toString(36).substring(2, 9);
 
-// Supported file extensions for drag-and-drop
+// Supported image file extensions
 const SUPPORTED_EXTENSIONS = new Set(['nef', 'cr2', 'arw', 'jpg', 'jpeg', 'png', 'tiff']);
 
 /**
@@ -882,7 +882,23 @@ export function FileQueueModule({ node }) {
 
     const effectivePosition = position === 'default' ? getInsertModePreference() : position;
 
-    const newItems = filePaths.map(filePath => {
+    // Filter out unsupported file types (e.g. XMP sidecars from glob expansion)
+    const supportedPaths = filePaths.filter(fp => {
+      const ext = fp.split('.').pop()?.toLowerCase();
+      return ext && SUPPORTED_EXTENSIONS.has(ext);
+    });
+    const skippedCount = filePaths.length - supportedPaths.length;
+    if (skippedCount > 0) {
+      debug('FileQueue', `Filtered out ${skippedCount} unsupported file(s)`);
+    }
+    if (supportedPaths.length === 0) {
+      if (skippedCount > 0) {
+        showToast(`No supported image files (skipped ${skippedCount} non-image files)`, 'warning', 3000);
+      }
+      return;
+    }
+
+    const newItems = supportedPaths.map(filePath => {
       const fileName = filePath.split('/').pop();
       const alreadyProcessed = currentProcessedFiles.has(fileName);
       debug('FileQueue', '>>> addFiles item', { fileName, alreadyProcessed });

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { useModuleEvent, useEmitEvent } from '../hooks/useModuleEvent.js';
+import { useModuleEvent, useEmitEvent, useModuleAPI } from '../hooks/useModuleEvent.js';
 import { useBackend } from '../context/BackendContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import { debug, debugWarn, debugError } from '../shared/debug.js';
@@ -205,6 +205,7 @@ const SUPPORTED_EXTENSIONS = new Set(['nef', 'cr2', 'arw', 'jpg', 'jpeg', 'png',
 export function FileQueueModule({ node }) {
   const { api, isConnected } = useBackend();
   const emit = useEmitEvent();
+  const { hasListeners, waitForListeners } = useModuleAPI();
   const globalShowToast = useToast();
 
   // Queue state
@@ -1131,6 +1132,17 @@ export function FileQueueModule({ node }) {
       window.workspace.openModule('image-viewer');
     }
 
+    // Wait for ImageViewer to mount and register its load-image handler.
+    // openModule may create or activate the tab, but React renders async —
+    // emitting before the component mounts loses the event.
+    if (!hasListeners('load-image')) {
+      debug('FileQueue', 'Waiting for load-image listener (ImageViewer mounting)...');
+      const ready = await waitForListeners('load-image', 2000, 10);
+      if (!ready) {
+        debugWarn('FileQueue', 'Timeout waiting for ImageViewer - emitting anyway');
+      }
+    }
+
     if (fixModeRef.current && item.isAlreadyProcessed) {
       try {
         debug('FileQueue', 'Undoing file for fix mode:', item.fileName);
@@ -1156,7 +1168,7 @@ export function FileQueueModule({ node }) {
     debug('FileQueue', 'Emitting load-image for:', item.filePath, { skipAutoDetect });
     emit('load-image', { imagePath: item.filePath, skipAutoDetect });
     emitQueueStatus(index);
-  }, [api, loadProcessedFiles, emit, showToast, emitQueueStatus]);
+  }, [api, loadProcessedFiles, emit, hasListeners, waitForListeners, showToast, emitQueueStatus]);
 
   loadFileRef.current = loadFile;
 

--- a/frontend/src/renderer/components/ImageViewer.jsx
+++ b/frontend/src/renderer/components/ImageViewer.jsx
@@ -492,6 +492,15 @@ export function ImageViewer() {
     setPan({ x: 0, y: 0 });
   }, []);
 
+  // Refs for zoom functions — useModuleEvent captures handlers at subscription
+  // time, so without refs the handlers would use stale closures from mount
+  const zoomRef = useRef(zoom);
+  zoomRef.current = zoom;
+  const resetZoomRef = useRef(resetZoom);
+  resetZoomRef.current = resetZoom;
+  const autoFitRef = useRef(autoFit);
+  autoFitRef.current = autoFit;
+
   // ============================================
   // Menu State Sync Helper
   // ============================================
@@ -773,10 +782,10 @@ export function ImageViewer() {
   useModuleEvent('boxes-hide', () => setBoxMode('none'));
   useModuleEvent('boxes-all', () => setBoxMode('all'));
   useModuleEvent('boxes-single', () => setBoxMode('single'));
-  useModuleEvent('zoom-in', () => zoom(ZOOM_STEP, mousePosRef.current.x, mousePosRef.current.y));
-  useModuleEvent('zoom-out', () => zoom(1 / ZOOM_STEP, mousePosRef.current.x, mousePosRef.current.y));
-  useModuleEvent('reset-zoom', resetZoom);
-  useModuleEvent('auto-fit', autoFit);
+  useModuleEvent('zoom-in', () => zoomRef.current(ZOOM_STEP, mousePosRef.current.x, mousePosRef.current.y));
+  useModuleEvent('zoom-out', () => zoomRef.current(1 / ZOOM_STEP, mousePosRef.current.x, mousePosRef.current.y));
+  useModuleEvent('reset-zoom', () => resetZoomRef.current());
+  useModuleEvent('auto-fit', () => autoFitRef.current());
   useModuleEvent('auto-center-enable', () => toggleAutoCenterOnFace(true));
   useModuleEvent('auto-center-disable', () => toggleAutoCenterOnFace(false));
   useModuleEvent('file-info-show', () => toggleFileInfo(true));

--- a/frontend/src/renderer/components/LogViewer.jsx
+++ b/frontend/src/renderer/components/LogViewer.jsx
@@ -83,8 +83,7 @@ export function LogViewer() {
   }, [logs]);
 
   /**
-   * Poll log buffer for new entries
-   * This approach avoids console interception issues and captures all debug() logs
+   * Listen for new log entries via CustomEvent from debug buffer
    */
   useEffect(() => {
     // Load initial logs from buffer
@@ -94,21 +93,21 @@ export function LogViewer() {
       lastBufferLengthRef.current = initialLogs.length;
     }
 
-    // Poll for new entries every 100ms
-    const pollInterval = setInterval(() => {
+    // React to new entries via event (replaces 100ms polling)
+    const handleBufferChanged = () => {
       const buffer = getLogBuffer();
       if (buffer.length > lastBufferLengthRef.current) {
-        // Get only new entries
         const newEntries = buffer.slice(lastBufferLengthRef.current);
         setLogs(prev => [...prev, ...newEntries]);
         lastBufferLengthRef.current = buffer.length;
       }
-    }, 100);
+    };
 
-    debug('LogViewer', 'Initialized - polling debug buffer');
+    window.addEventListener('debug-buffer-changed', handleBufferChanged);
+    debug('LogViewer', 'Initialized - listening for debug buffer events');
 
     return () => {
-      clearInterval(pollInterval);
+      window.removeEventListener('debug-buffer-changed', handleBufferChanged);
     };
   }, []);
 

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -85,7 +85,7 @@ function useDropdownPosition(open, anchorEl, { maxHeight = 200, gap = 4 } = {}) 
 /**
  * ReviewModule Component
  */
-export function ReviewModule() {
+export function ReviewModule({ node }) {
   const { api } = useBackend();
   const emit = useEmitEvent();
   const showToast = useToast();
@@ -720,10 +720,8 @@ export function ReviewModule() {
    */
   useEffect(() => {
     const handleKeyboard = (e) => {
-      const reviewModuleVisible = document.querySelector('.review-module') !== null;
-      if (!reviewModuleVisible) {
-        return;
-      }
+      // Skip keyboard handling when this tab is hidden in FlexLayout
+      if (node && !node.isVisible()) return;
 
       const activeEl = document.activeElement;
       const isInput = e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable;

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -536,15 +536,11 @@ export function ReviewModule() {
     setStatus(`Saving ${totalChanges} changes...`);
 
     try {
-      // Save confirmations
-      for (const confirmation of pendingConfirmations) {
-        await api.post('/api/v1/confirm-identity', confirmation);
-      }
-
-      // Save ignores
-      for (const ignore of pendingIgnores) {
-        await api.post('/api/v1/ignore-face', ignore);
-      }
+      // Batch save: single request instead of N individual calls
+      await api.post('/api/v1/batch-confirm', {
+        confirmations: pendingConfirmations,
+        ignores: pendingIgnores
+      });
 
       setPendingConfirmations([]);
       setPendingIgnores([]);

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -110,6 +110,10 @@ export function ReviewModule() {
   const inputRefs = useRef({});
   const cardRefs = useRef({});
   const detectAbortRef = useRef(null);
+  const detectedFacesRef = useRef(detectedFaces);
+
+  // Keep detectedFacesRef in sync with state (for use in timeout callbacks)
+  useEffect(() => { detectedFacesRef.current = detectedFaces; }, [detectedFaces]);
 
   /**
    * Load people names for autocomplete
@@ -664,6 +668,12 @@ export function ReviewModule() {
 
     if (allDone && hasChanges) {
       const timeout = setTimeout(async () => {
+        // Re-check with current ref — new faces may have been added since timeout was scheduled
+        const currentFaces = detectedFacesRef.current;
+        const stillAllDone = currentFaces.length > 0 &&
+          currentFaces.every(f => f.is_confirmed || f.is_rejected);
+        if (!stillAllDone) return;
+
         const saveSuccess = await saveAllChanges();
         if (!saveSuccess) {
           // Don't proceed if save failed - user needs to retry or discard

--- a/frontend/src/renderer/components/filterExpression.js
+++ b/frontend/src/renderer/components/filterExpression.js
@@ -1,0 +1,107 @@
+/**
+ * filterExpression - Parse and evaluate filter expressions with | (OR), & (AND), and parentheses.
+ *
+ * Syntax:
+ *   vilm|max        → matches "vilm" OR "max"
+ *   vilm&max        → matches "vilm" AND "max"
+ *   (vilm|max)&2506 → ("vilm" OR "max") AND "2506"
+ *   vilm             → simple substring match
+ *
+ * Precedence: & binds tighter than |, so a|b&c = a|(b&c).
+ * Parentheses override precedence.
+ * Leading/trailing * on atoms are stripped (glob compat).
+ * All matching is case-insensitive.
+ *
+ * Grammar:
+ *   expr   = term ('|' term)*
+ *   term   = factor ('&' factor)*
+ *   factor = '(' expr ')' | atom
+ *   atom   = [^|&()]+
+ */
+
+/**
+ * Parse a filter expression string into an AST.
+ * @param {string} input
+ * @returns {object} AST node: { type: 'atom', value } | { type: 'or'|'and', children }
+ */
+export function parseFilterExpression(input) {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  let pos = 0;
+
+  function peek() { return trimmed[pos]; }
+  function advance() { return trimmed[pos++]; }
+
+  function parseExpr() {
+    const children = [parseTerm()];
+    while (pos < trimmed.length && peek() === '|') {
+      advance(); // consume '|'
+      children.push(parseTerm());
+    }
+    return children.length === 1 ? children[0] : { type: 'or', children };
+  }
+
+  function parseTerm() {
+    const children = [parseFactor()];
+    while (pos < trimmed.length && peek() === '&') {
+      advance(); // consume '&'
+      children.push(parseFactor());
+    }
+    return children.length === 1 ? children[0] : { type: 'and', children };
+  }
+
+  function parseFactor() {
+    if (peek() === '(') {
+      advance(); // consume '('
+      const node = parseExpr();
+      if (peek() === ')') advance(); // consume ')'
+      return node;
+    }
+    return parseAtom();
+  }
+
+  function parseAtom() {
+    let value = '';
+    while (pos < trimmed.length && peek() !== '|' && peek() !== '&' && peek() !== '(' && peek() !== ')') {
+      value += advance();
+    }
+    // Strip glob-style leading/trailing * and whitespace
+    value = value.replace(/^\*+|\*+$/g, '').trim().toLowerCase();
+    return { type: 'atom', value };
+  }
+
+  return parseExpr();
+}
+
+/**
+ * Evaluate an AST node against a text string.
+ * @param {object} node - AST node from parseFilterExpression
+ * @param {string} text - The text to match against (should be lowercase)
+ * @returns {boolean}
+ */
+export function evaluateFilter(node, text) {
+  if (!node) return true;
+
+  switch (node.type) {
+    case 'atom':
+      return !node.value || text.includes(node.value);
+    case 'or':
+      return node.children.some(child => evaluateFilter(child, text));
+    case 'and':
+      return node.children.every(child => evaluateFilter(child, text));
+    default:
+      return true;
+  }
+}
+
+/**
+ * Convenience: compile a filter expression into a matcher function.
+ * @param {string} expression - Filter expression string
+ * @returns {function(string): boolean} - Matcher that takes text and returns true/false
+ */
+export function compileFilter(expression) {
+  const ast = parseFilterExpression(expression);
+  if (!ast) return () => true;
+  return (text) => evaluateFilter(ast, text.toLowerCase());
+}

--- a/frontend/src/renderer/hooks/useKeyboardShortcuts.js
+++ b/frontend/src/renderer/hooks/useKeyboardShortcuts.js
@@ -107,14 +107,18 @@ export function useKeyHold(key, callbacks, options = {}) {
   const doubleTapTimeoutRef = useRef(null);
   const pendingSingleTapRef = useRef(null);
   const justDoubleTappedRef = useRef(false); // Prevent extra tap after double-tap
+  const activeCodeRef = useRef(null); // Track physical key for reliable keyup matching
 
   useEffect(() => {
     const handleKeyDown = (event) => {
       if (shouldIgnoreEvent(event)) return;
       if (event.key !== key) return;
       if (event.repeat) return; // Ignore OS key repeat
+      // Ignore Cmd/Ctrl combos — let menu accelerators handle those
+      if (event.metaKey || event.ctrlKey) return;
 
       event.preventDefault();
+      activeCodeRef.current = event.code; // Store physical key (e.g. 'Equal' for +/=)
 
       const now = Date.now();
 
@@ -181,7 +185,11 @@ export function useKeyHold(key, callbacks, options = {}) {
     };
 
     const handleKeyUp = (event) => {
-      if (event.key !== key) return;
+      // Match by physical key code (event.code) instead of event.key to handle
+      // cases where modifier release changes the key identity (e.g. releasing
+      // Shift before '=' turns '+' keyup into '=' keyup)
+      if (!activeCodeRef.current || event.code !== activeCodeRef.current) return;
+      activeCodeRef.current = null;
 
       // Clear hold timers
       if (holdTimeoutRef.current) {
@@ -240,7 +248,7 @@ export function useKeyHold(key, callbacks, options = {}) {
 
       // Cleanup timers
       if (holdTimeoutRef.current) clearTimeout(holdTimeoutRef.current);
-      if (repeatIntervalRef.current) clearInterval(repeatIntervalRef.current);
+      if (repeatIntervalRef.current) cancelAnimationFrame(repeatIntervalRef.current);
       if (doubleTapTimeoutRef.current) clearTimeout(doubleTapTimeoutRef.current);
     };
   }, [key, holdDelay, repeatInterval, doubleTapDelay]); // Only re-subscribe when key or timing options change

--- a/frontend/src/renderer/shared/debug.js
+++ b/frontend/src/renderer/shared/debug.js
@@ -195,6 +195,9 @@ function addToBuffer(level, message, source = 'frontend') {
     logBuffer.shift();
   }
 
+  // Notify listeners (LogViewer uses this instead of polling)
+  window.dispatchEvent(new CustomEvent('debug-buffer-changed'));
+
   // Send to file if enabled
   const formattedMessage = `${timestamp} [${level.toUpperCase()}] ${message}`;
   sendToFile(level, formattedMessage);

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -527,7 +527,7 @@ export function FlexLayoutWorkspace() {
       );
     }
 
-    return <ModuleComponent />;
+    return <ModuleComponent node={node} />;
   }, []);
 
   // Get tabset position in layout (using bounding rect)

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -337,7 +337,7 @@ export function FlexLayoutWorkspace() {
     // Ensure critical global settings are always applied
     // (saved layouts may not have newer settings)
     const criticalSettings = {
-      tabEnableRenderOnDemand: false,  // Keep all tabs mounted for event handling
+      tabEnableRenderOnDemand: true,   // Unmount hidden tabs to save CPU
       splitterSize: 4,                  // Consistent splitter appearance
       tabSetMinWidth: 100,              // Prevent panels from becoming too small
       tabSetMinHeight: 100,

--- a/frontend/src/renderer/workspace/flexlayout/layouts.js
+++ b/frontend/src/renderer/workspace/flexlayout/layouts.js
@@ -19,7 +19,7 @@ export const reviewLayout = {
     borderMinSize: 100,
     splitterSize: 4,
     enableEdgeDock: true,
-    tabEnableRenderOnDemand: false  // Keep all tabs mounted for event handling
+    tabEnableRenderOnDemand: true  // Unmount hidden tabs to save CPU
   },
   layout: {
     type: 'row',
@@ -33,6 +33,7 @@ export const reviewLayout = {
             type: 'tab',
             name: 'Review',
             component: 'review-module',
+            enableRenderOnDemand: false,
             config: { moduleId: 'review-module' }
           }
         ]
@@ -73,7 +74,7 @@ export const reviewWithLogsLayout = {
     borderMinSize: 100,
     splitterSize: 4,
     enableEdgeDock: true,
-    tabEnableRenderOnDemand: false  // Keep all tabs mounted for event handling
+    tabEnableRenderOnDemand: true  // Unmount hidden tabs to save CPU
   },
   layout: {
     type: 'row',
@@ -139,7 +140,7 @@ export const comparisonLayout = {
     borderMinSize: 100,
     splitterSize: 4,
     enableEdgeDock: true,
-    tabEnableRenderOnDemand: false  // Keep all tabs mounted for event handling
+    tabEnableRenderOnDemand: true  // Unmount hidden tabs to save CPU
   },
   layout: {
     type: 'row',
@@ -193,7 +194,7 @@ export const fullReviewLayout = {
     borderMinSize: 100,
     splitterSize: 4,
     enableEdgeDock: true,
-    tabEnableRenderOnDemand: false  // Keep all tabs mounted for event handling
+    tabEnableRenderOnDemand: true  // Unmount hidden tabs to save CPU
   },
   layout: {
     type: 'row',
@@ -282,7 +283,7 @@ export const queueReviewLayout = {
     borderMinSize: 100,
     splitterSize: 4,
     enableEdgeDock: true,
-    tabEnableRenderOnDemand: false  // Keep all tabs mounted for event handling
+    tabEnableRenderOnDemand: true  // Unmount hidden tabs to save CPU
   },
   layout: {
     type: 'row',
@@ -296,6 +297,7 @@ export const queueReviewLayout = {
             type: 'tab',
             name: 'File Queue',
             component: 'file-queue',
+            enableRenderOnDemand: false,
             config: { moduleId: 'file-queue' }
           }
         ]
@@ -308,6 +310,7 @@ export const queueReviewLayout = {
             type: 'tab',
             name: 'Review',
             component: 'review-module',
+            enableRenderOnDemand: false,
             config: { moduleId: 'review-module' }
           }
         ]
@@ -342,7 +345,7 @@ export const databaseLayout = {
     borderMinSize: 100,
     splitterSize: 4,
     enableEdgeDock: true,
-    tabEnableRenderOnDemand: false  // Keep all tabs mounted for event handling
+    tabEnableRenderOnDemand: true  // Unmount hidden tabs to save CPU
   },
   layout: {
     type: 'row',

--- a/frontend/src/renderer/workspace/preferences.js
+++ b/frontend/src/renderer/workspace/preferences.js
@@ -18,7 +18,7 @@ export class PreferencesManager {
       backend: {
         autoStart: true,
         port: 5001, // Changed from 5000 to avoid macOS Control Center conflict
-        pythonPath: '/Users/krisniem/.local/share/miniforge3/envs/hitta_ansikten/bin/python3'
+        pythonPath: ''  // Empty = auto-detect (backend/.venv or ANSIKTEN_PYTHON)
       },
       ui: {
         theme: 'system', // 'dark' | 'light' | 'system'


### PR DESCRIPTION
Release v1.2.0 — promotes the accumulated `dev` work to `master` for tagging.

## Highlights
- **Added:** file queue filter bar (`/` or `Cmd+F`) with filename pattern / expression syntax and match count; rename/clear-done scope to filtered items.
- **Fixed:** runaway Cmd+/Cmd- zoom, stale-closure menu zoom commands, empty image viewer on first double-click, non-image files (XMP sidecars) leaking into the queue, focused-vs-selected separation in the file queue.
- **Changed:** convention-based `.venv` discovery, dependency management migrated to `pyproject.toml`, CI updated accordingly.

See CHANGELOG.md `[1.2.0]` for the full list.