### PR TITLE
(feature) Add queue overview bar to Review panel

### DIFF
--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -103,6 +103,12 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
    - **Namnge** (`R` eller skriv i fältet) för nytt namn
    - **Välj alternativ** (`1-9`) för annan matchning
 
+Längst ner i Face Review-panelen visas en **kööversikt** som en
+färgad stapel över hela kön: grönt = granskade den här sessionen,
+orange = förbearbetade (i cachen, snabba att öppna) men ännu inte
+granskade, grått = återstår. Håll muspekaren över stapeln för exakta
+antal.
+
 ### 3. Spara och fortsätt
 
 1. När alla ansikten är granskade:

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -326,6 +326,18 @@ export function FileQueueModule({ node }) {
     });
   }, [emit, currentIndex]);
 
+  // Keep the Review queue-overview bar live: re-emit when files finish
+  // preprocessing in the background (the completion paths only update
+  // preprocessingStatus, they don't load/complete a file), and answer a
+  // late subscriber that asks for the current status on mount.
+  useEffect(() => {
+    emitQueueStatus();
+  }, [preprocessingStatus, emitQueueStatus]);
+
+  useModuleEvent('request-queue-status', useCallback(() => {
+    emitQueueStatus();
+  }, [emitQueueStatus]));
+
   useEffect(() => {
     loadProcessedFiles();
   }, [loadProcessedFiles]);

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -316,11 +316,13 @@ export function FileQueueModule({ node }) {
     const done = q.filter(item => item.status === 'completed').length;
     // Remaining = total - done, but minimum 0 (avoid -1 when queue is empty)
     const remaining = Math.max(0, q.length - done);
+    const preprocessed = countPreprocessed(q);
     emit('queue-status', {
       total: q.length,
       current: currentIdx,
       done: done,
-      remaining: remaining
+      remaining: remaining,
+      preprocessed: preprocessed
     });
   }, [emit, currentIndex]);
 
@@ -553,6 +555,16 @@ export function FileQueueModule({ node }) {
   // Use refs to avoid re-subscribing on every preprocessingStatus change
   const preprocessingStatusRef = useRef(preprocessingStatus);
   preprocessingStatusRef.current = preprocessingStatus;
+
+  // Count files that are preprocessed (in the cache, ready to open) but not yet
+  // reviewed this session. Used for the queue overview bar in ReviewModule.
+  const countPreprocessed = useCallback((queueArr) => {
+    const pp = preprocessingStatusRef.current;
+    return queueArr.filter(
+      item => item.status !== 'completed' &&
+              pp[item.filePath]?.status === PreprocessingStatus.COMPLETED
+    ).length;
+  }, []);
 
   useEffect(() => {
     const handleFileDeleted = (filePath) => {
@@ -1562,11 +1574,19 @@ export function FileQueueModule({ node }) {
 
       const prevDone = currentQueue.filter(q => q.status === 'completed').length;
       const newDone = success ? prevDone + 1 : prevDone;
+      // Patch the just-reviewed file to 'completed' so it isn't also counted as
+      // preprocessed (setQueue above is async, so currentQueue is still stale here).
+      const patchedQueue = success
+        ? currentQueue.map(item =>
+            item.filePath === imagePath ? { ...item, status: 'completed' } : item
+          )
+        : currentQueue;
       emit('queue-status', {
         total: currentQueue.length,
         current: nextIdx >= 0 ? nextIdx : currentIdx,
         done: newDone,
-        remaining: Math.max(0, currentQueue.length - newDone)
+        remaining: Math.max(0, currentQueue.length - newDone),
+        preprocessed: countPreprocessed(patchedQueue)
       });
 
       // Show toast for review result

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -326,13 +326,14 @@ export function FileQueueModule({ node }) {
     });
   }, [emit, currentIndex]);
 
-  // Keep the Review queue-overview bar live: re-emit when files finish
-  // preprocessing in the background (the completion paths only update
-  // preprocessingStatus, they don't load/complete a file), and answer a
+  // Keep the Review queue-overview bar live: re-emit when the queue itself
+  // changes (add files, clear completed, remove — none of which load or
+  // complete a file) and when files finish preprocessing in the background
+  // (the completion paths only update preprocessingStatus). Also answer a
   // late subscriber that asks for the current status on mount.
   useEffect(() => {
     emitQueueStatus();
-  }, [preprocessingStatus, emitQueueStatus]);
+  }, [queue, preprocessingStatus, emitQueueStatus]);
 
   useModuleEvent('request-queue-status', useCallback(() => {
     emitQueueStatus();

--- a/frontend/src/renderer/components/ReviewModule.css
+++ b/frontend/src/renderer/components/ReviewModule.css
@@ -383,3 +383,30 @@
   color: var(--text-tertiary);
   text-align: center;
 }
+
+/* Queue overview bar (footer) */
+.review-queue-bar {
+  display: flex;
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-elevated);
+}
+
+.review-queue-bar .seg {
+  height: 100%;
+  transition: width var(--transition-slow);
+}
+
+.review-queue-bar .seg-done {
+  background: var(--color-success);
+}
+
+.review-queue-bar .seg-cached {
+  background: var(--color-warning);
+}
+
+.review-queue-bar .seg-remaining {
+  background: var(--bg-elevated);
+}

--- a/frontend/src/renderer/components/ReviewModule.css
+++ b/frontend/src/renderer/components/ReviewModule.css
@@ -407,6 +407,4 @@
   background: var(--color-warning);
 }
 
-.review-queue-bar .seg-remaining {
-  background: var(--bg-elevated);
-}
+/* "Remaining" needs no segment — the bar track (--bg-elevated) shows through. */

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -1003,9 +1003,7 @@ export function ReviewModule({ node }) {
               {preprocessed > 0 && (
                 <div className="seg seg-cached" style={{ width: `${pct(preprocessed)}%` }} />
               )}
-              {remaining > 0 && (
-                <div className="seg seg-remaining" style={{ width: `${pct(remaining)}%` }} />
-              )}
+              {/* "remaining" is the bar track itself (var(--bg-elevated)) showing through */}
             </div>
           </div>
         );

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -103,6 +103,7 @@ export function ReviewModule({ node }) {
   const [clearInputTrigger, setClearInputTrigger] = useState(0);
   const [confirmDialog, setConfirmDialog] = useState(null);
   const [undoStack, setUndoStack] = useState([]);
+  const [queueStatus, setQueueStatus] = useState(null);
 
   // Refs
   const moduleRef = useRef(null);
@@ -920,6 +921,7 @@ export function ReviewModule({ node }) {
    */
   useModuleEvent('save-all-changes', saveAllChanges);
   useModuleEvent('discard-changes', discardChanges);
+  useModuleEvent('queue-status', setQueueStatus);
   useModuleEvent('undo-face-action', useCallback(() => {
     const undone = undoLastAction();
     if (undone) {
@@ -979,6 +981,30 @@ export function ReviewModule({ node }) {
           ))
         )}
       </div>
+
+      {queueStatus && queueStatus.total > 0 && (() => {
+        const { total, done, preprocessed = 0 } = queueStatus;
+        const remaining = Math.max(0, total - done - preprocessed);
+        const pct = (n) => (n / total) * 100;
+        return (
+          <div className="module-footer review-footer">
+            <div
+              className="review-queue-bar"
+              title={`${done} granskade · ${preprocessed} redo · ${remaining} kvar`}
+            >
+              {done > 0 && (
+                <div className="seg seg-done" style={{ width: `${pct(done)}%` }} />
+              )}
+              {preprocessed > 0 && (
+                <div className="seg seg-cached" style={{ width: `${pct(preprocessed)}%` }} />
+              )}
+              {remaining > 0 && (
+                <div className="seg seg-remaining" style={{ width: `${pct(remaining)}%` }} />
+              )}
+            </div>
+          </div>
+        );
+      })()}
 
       {confirmDialog && (
         <ConfirmDialog

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -922,6 +922,11 @@ export function ReviewModule({ node }) {
   useModuleEvent('save-all-changes', saveAllChanges);
   useModuleEvent('discard-changes', discardChanges);
   useModuleEvent('queue-status', setQueueStatus);
+  // Pull the current queue status on mount so the overview bar isn't blank
+  // when the Review panel is opened after navigation has already happened.
+  useEffect(() => {
+    emit('request-queue-status');
+  }, [emit]);
   useModuleEvent('undo-face-action', useCallback(() => {
     const undone = undoLastAction();
     if (undone) {


### PR DESCRIPTION
## Summary

Adds a segmented progress bar at the bottom of the **Review** module giving an at-a-glance overview of the whole queue, addressing the lack of any queue-wide progress indicator during review.

Three colour segments (theme-aware, work in both light/dark):

- 🟩 **Green** — reviewed this session (`status === 'completed'`)
- 🟧 **Orange** — preprocessed (in the cache, ready to open) but not yet reviewed
- ⬜ **Grey** — remaining (neither reviewed nor preprocessed)

Only the bar is shown; exact counts appear in a hover tooltip (`X granskade · Y redo · Z kvar`) to keep the row clean.

## Changes

- **FileQueueModule.jsx** — extends the existing `queue-status` event with a `preprocessed` count via a stable `countPreprocessed()` helper (uses `preprocessingStatusRef`, `PreprocessingStatus.COMPLETED`). Both emit sites updated; the review-complete site patches the just-reviewed file to `completed` first so it isn't double-counted. `done`/`remaining`/`total` are unchanged, so the ImageViewer overlay keeps working.
- **ReviewModule.jsx** — subscribes to `queue-status` and renders the segmented bar in a `.module-footer`.
- **ReviewModule.css** — `.review-queue-bar` + the three `.seg` colours using existing theme variables.

## Testing

- `npm run build:workspace` passes.
- Manual: add files to the queue, observe grey shrink as preprocessing fills orange, and green grow as images are reviewed; hover shows exact counts.