### PR TITLE
Fix Refine Faces preview 404 and shape-repair crash

### DIFF
--- a/frontend/src/renderer/components/RefineFacesModule.jsx
+++ b/frontend/src/renderer/components/RefineFacesModule.jsx
@@ -65,7 +65,7 @@ export function RefineFacesModule() {
       params.set('mahalanobis_threshold', config.mahalanobisThreshold.toString());
       params.set('min_encodings', config.minEncodings.toString());
 
-      const result = await api.get(`/api/refinement/preview?${params.toString()}`);
+      const result = await api.get(`/api/v1/refinement/preview?${params.toString()}`);
       setPreview(result);
 
       if (result.summary.total_remove === 0) {
@@ -128,7 +128,7 @@ export function RefineFacesModule() {
    */
   const handleRepairShapes = useCallback(async (dryRun = false) => {
     setIsLoading(true);
-    setStatus({ type: '', message: '' });
+    clearStatus();
 
     try {
       const body = {


### PR DESCRIPTION
## Problem

The **Refine Faces** module showed `Preview failed: HTTP 404: Not Found` when clicking **Preview**.

Root cause was a frontend URL typo, not a missing model/download (the InsightFace model is loaded and scipy/sklearn are installed):

- Preview called `/api/refinement/preview` — **missing the `/v1` prefix** the backend router is mounted under. The sibling `apply`/`repair-shapes` calls already included `/v1`, which is why only Preview failed.

A second latent bug crashed **Shape Repair**: `handleRepairShapes` called `setStatus(...)`, which is never destructured from `useOperationStatus` (only `clearStatus` is) → `ReferenceError` on every Simulate/Repair click.

## Changes

`frontend/src/renderer/components/RefineFacesModule.jsx`:

1. Preview URL → `/api/v1/refinement/preview` (matches the other refinement calls).
2. `setStatus({ type: '', message: '' })` → `clearStatus()` in `handleRepairShapes`, matching `handlePreview`.

## Verification

- `/api/v1/refinement/preview` returns HTTP 200 with real outlier data (verified against running backend).
- `npm run build:workspace` builds cleanly; bundle contains the corrected path only.
- End-to-end through the UI: Preview → Apply, and Simulate repair → Repair shapes all work.