### PR TITLE
GUI onboarding: Räkna spelare (counting) + Gallra spelare (culling)

### DIFF
--- a/backend/api/routes/culling.py
+++ b/backend/api/routes/culling.py
@@ -25,6 +25,7 @@ class CullingFilesRequest(BaseModel):
     date_from: Optional[str] = None
     date_to: Optional[str] = None
     player: Optional[str] = None
+    name_glob: Optional[str] = None
 
 
 class TrashRequest(BaseModel):
@@ -51,6 +52,7 @@ async def list_files(request: CullingFilesRequest):
             date_from=request.date_from,
             date_to=request.date_to,
             player=request.player,
+            name_glob=request.name_glob,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/api/routes/culling.py
+++ b/backend/api/routes/culling.py
@@ -1,0 +1,99 @@
+"""Culling API Routes
+
+Stats-driven culling workspace: list a player's image files and soft-delete /
+restore them via the app-managed trash.
+"""
+
+import logging
+from typing import List, Literal, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..services.culling_service import culling_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class CullingFilesRequest(BaseModel):
+    roots: List[str] = []
+    globs: List[str] = []
+    extension_preset: Optional[str] = "jpg"
+    recursive: bool = True
+    date_from: Optional[str] = None
+    date_to: Optional[str] = None
+    player: Optional[str] = None
+
+
+class TrashRequest(BaseModel):
+    paths: List[str]
+
+
+class RestoreRequest(BaseModel):
+    ids: List[str]
+
+
+class EmptyRequest(BaseModel):
+    ids: Optional[List[str]] = None
+
+
+@router.post("/culling/files")
+async def list_files(request: CullingFilesRequest):
+    """List image files for the current filter, optionally restricted to a player."""
+    try:
+        return culling_service.list_files(
+            roots=request.roots,
+            globs=request.globs,
+            extension_preset=request.extension_preset,
+            recursive=request.recursive,
+            date_from=request.date_from,
+            date_to=request.date_to,
+            player=request.player,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("Culling list failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/culling/trash")
+async def trash(request: TrashRequest):
+    """Soft-delete files to the app trash."""
+    try:
+        return culling_service.trash(request.paths)
+    except Exception as e:
+        logger.exception("Culling trash failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/culling/trash")
+async def list_trash():
+    """List items currently in the app trash."""
+    try:
+        return culling_service.list_trash()
+    except Exception as e:
+        logger.exception("Culling list-trash failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/culling/restore")
+async def restore(request: RestoreRequest):
+    """Restore trashed items to their original locations."""
+    try:
+        return culling_service.restore(request.ids)
+    except Exception as e:
+        logger.exception("Culling restore failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/culling/empty")
+async def empty(request: EmptyRequest):
+    """Permanently delete trashed items (all, or the given ids)."""
+    try:
+        return culling_service.empty(request.ids)
+    except Exception as e:
+        logger.exception("Culling empty failed")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/routes/player_count.py
+++ b/backend/api/routes/player_count.py
@@ -1,0 +1,63 @@
+"""Player Count API Routes
+
+GUI surface for the rakna_spelare CLI: count images per named person across a
+folder/glob/date-span selection.
+"""
+
+import logging
+from typing import List, Literal, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..services.player_count_service import player_count_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class PlayerCountRequest(BaseModel):
+    """Folder/glob/date-span selection plus counting options."""
+
+    roots: List[str] = []
+    globs: List[str] = []
+    extension_preset: Optional[str] = None  # 'jpg' | 'nef' | 'raw' | 'images' | 'all'
+    extensions: Optional[List[str]] = None  # explicit override, e.g. ['.jpg']
+    recursive: bool = True
+    date_from: Optional[str] = None  # YYYY-MM-DD or YYMMDD
+    date_to: Optional[str] = None
+    gap_minutes: int = 30
+    baseline: Literal["median", "mean"] = "median"
+    min_images: int = 3
+    per_match: bool = False
+    tranare: Optional[List[str]] = None  # override coach exclusion list
+    publik: Optional[List[str]] = None  # override audience exclusion list
+
+
+@router.post("/players/count")
+async def count_players(request: PlayerCountRequest):
+    """Resolve the selection and return per-player image counts + statistics."""
+    try:
+        return player_count_service.count(
+            roots=request.roots,
+            globs=request.globs,
+            extension_preset=request.extension_preset,
+            extensions=request.extensions,
+            recursive=request.recursive,
+            date_from=request.date_from,
+            date_to=request.date_to,
+            gap_minutes=request.gap_minutes,
+            baseline=request.baseline,
+            min_images=request.min_images,
+            per_match=request.per_match,
+            tranare=request.tranare,
+            publik=request.publik,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.exception("Player count failed")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -210,11 +210,13 @@ async def health_check():
 API_V1_PREFIX = "/api/v1"
 
 # Import routes
-from .routes import detection, status, database, statistics, management, preprocessing, files, startup, refinement
+from .routes import detection, status, database, statistics, management, preprocessing, files, startup, refinement, player_count, culling
 app.include_router(detection.router, prefix=API_V1_PREFIX, tags=["detection"])
 app.include_router(status.router, prefix=API_V1_PREFIX, tags=["status"])
 app.include_router(database.router, prefix=API_V1_PREFIX, tags=["database"])
 app.include_router(statistics.router, prefix=API_V1_PREFIX, tags=["statistics"])
+app.include_router(player_count.router, prefix=API_V1_PREFIX, tags=["players"])
+app.include_router(culling.router, prefix=API_V1_PREFIX, tags=["culling"])
 app.include_router(management.router, prefix=API_V1_PREFIX, tags=["management"])
 app.include_router(refinement.router, prefix=API_V1_PREFIX, tags=["refinement"])
 app.include_router(preprocessing.router, prefix=f"{API_V1_PREFIX}/preprocessing", tags=["preprocessing"])

--- a/backend/api/services/culling_service.py
+++ b/backend/api/services/culling_service.py
@@ -200,8 +200,14 @@ class CullingService:
                 continue
             try:
                 dest = self._restore_one(entry["original_path"], entry["stored_name"])
+                # Sidecars must land beside the *actual* restored image: when the
+                # original path was occupied and the image came back as
+                # <stem>-restored, its .xmp must follow to <stem>-restored.xmp,
+                # not the original name (which would orphan the metadata).
                 for sc in entry.get("sidecars", []):
-                    self._restore_one(sc["original_path"], sc["stored_name"])
+                    sc_suffix = Path(sc["original_path"]).suffix
+                    sc_target = dest.with_name(dest.stem + sc_suffix)
+                    self._restore_one(str(sc_target), sc["stored_name"])
                 keep = [e for e in keep if e["id"] != tid]
                 restored.append({"id": tid, "restored_path": str(dest)})
             except Exception as e:

--- a/backend/api/services/culling_service.py
+++ b/backend/api/services/culling_service.py
@@ -1,0 +1,225 @@
+"""Culling Service
+
+Backs the stats-driven culling workspace: list a player's image files, and
+soft-delete (trash) / restore them with an app-managed, manifest-backed trash so
+deletions are always reversible.
+
+Reuses the shared file resolution (file_resolver) + filename parsing
+(rakna_spelare.build_entries) for listing, and the sidecar-aware move idea from
+filer2mappar for trashing. No face recognition — players are filename-derived.
+"""
+
+import json
+import logging
+import shutil
+import sys
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+# Backend root on sys.path to import the CLI parser (pattern shared with the
+# other services).
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from rakna_spelare import build_entries  # noqa: E402
+
+from .file_resolver import TRASH_DIR, preset_extensions, resolve_files  # noqa: E402
+from .rename_service import find_sidecar_files  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_PATH = TRASH_DIR / "manifest.jsonl"
+
+# Sidecar extensions to carry along when trashing/restoring (without dot).
+SIDECAR_EXTENSIONS = ["xmp"]
+
+
+class CullingService:
+    """List player files and trash/restore them reversibly."""
+
+    # ----- listing -------------------------------------------------------
+
+    def list_files(
+        self,
+        roots: list[str] | None = None,
+        globs: list[str] | None = None,
+        extension_preset: str | None = "jpg",
+        recursive: bool = True,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        player: str | None = None,
+    ) -> dict:
+        """Resolve files and return parsed entries, optionally filtered to a player.
+
+        Returns {files: [{path, basename, names, datetime}], players: [name,...]}.
+        ``players`` is the sorted set of names present across the resolved files
+        (for the filter dropdown). Raises ValueError when no input is given.
+        """
+        roots = roots or []
+        globs = globs or []
+        if not roots and not globs:
+            raise ValueError("Ange minst en mapp eller ett glob-mönster.")
+
+        files = resolve_files(
+            roots=roots,
+            globs=globs,
+            extensions=preset_extensions(extension_preset),
+            recursive=recursive,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        entries = build_entries(files)
+
+        all_names: set[str] = set()
+        out: list[dict] = []
+        for dt, names, path in entries:
+            all_names.update(names)
+            if player is not None and player not in names:
+                continue
+            out.append({
+                "path": path,
+                "basename": Path(path).name,
+                "names": names,
+                "datetime": dt.isoformat(),
+            })
+
+        return {"files": out, "players": sorted(all_names)}
+
+    # ----- trash manifest -----------------------------------------------
+
+    def _load_manifest(self) -> list[dict]:
+        if not MANIFEST_PATH.exists():
+            return []
+        entries: list[dict] = []
+        with open(MANIFEST_PATH, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    entries.append(json.loads(line))
+        return entries
+
+    def _rewrite_manifest(self, entries: list[dict]) -> None:
+        TRASH_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = MANIFEST_PATH.with_suffix(".jsonl.tmp")
+        with open(tmp, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e, ensure_ascii=False) + "\n")
+        tmp.replace(MANIFEST_PATH)
+
+    def _append_manifest(self, entry: dict) -> None:
+        TRASH_DIR.mkdir(parents=True, exist_ok=True)
+        with open(MANIFEST_PATH, "a") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    # ----- trash / restore ----------------------------------------------
+
+    def trash(self, paths: list[str]) -> dict:
+        """Move files (+ sidecars) to the app trash, recording how to restore them.
+
+        Returns {trashed: [{id, original_path, basename}], errors: [...]}.
+        """
+        TRASH_DIR.mkdir(parents=True, exist_ok=True)
+        trashed: list[dict] = []
+        errors: list[dict] = []
+
+        for p in paths:
+            src = Path(p)
+            if not src.is_file():
+                errors.append({"path": p, "error": "Filen finns inte"})
+                continue
+            try:
+                tid = uuid.uuid4().hex
+                stored_name = f"{tid}__{src.name}"
+                shutil.move(str(src), str(TRASH_DIR / stored_name))
+
+                stored_sidecars: list[dict] = []
+                for sc in find_sidecar_files(src, SIDECAR_EXTENSIONS):
+                    sc_stored = f"{tid}__{sc.name}"
+                    shutil.move(str(sc), str(TRASH_DIR / sc_stored))
+                    stored_sidecars.append({
+                        "original_path": str(sc),
+                        "stored_name": sc_stored,
+                    })
+
+                entry = {
+                    "id": tid,
+                    "original_path": str(src),
+                    "stored_name": stored_name,
+                    "basename": src.name,
+                    "sidecars": stored_sidecars,
+                    "trashed_at": datetime.now().isoformat(),
+                }
+                self._append_manifest(entry)
+                trashed.append({"id": tid, "original_path": str(src), "basename": src.name})
+            except Exception as e:
+                logger.exception("Failed to trash %s", p)
+                errors.append({"path": p, "error": str(e)})
+
+        return {"trashed": trashed, "errors": errors}
+
+    def list_trash(self) -> dict:
+        """Return active trash entries, newest first."""
+        entries = self._load_manifest()
+        entries.sort(key=lambda e: e.get("trashed_at", ""), reverse=True)
+        return {"items": entries}
+
+    def restore(self, ids: list[str]) -> dict:
+        """Move trashed files (+ sidecars) back to their original locations.
+
+        Never overwrites: if the original path is occupied, restores alongside as
+        ``<stem>-restored<suffix>``. Returns {restored: [...], errors: [...]}.
+        """
+        entries = self._load_manifest()
+        by_id = {e["id"]: e for e in entries}
+        restored: list[dict] = []
+        errors: list[dict] = []
+        keep = list(entries)
+
+        for tid in ids:
+            entry = by_id.get(tid)
+            if entry is None:
+                errors.append({"id": tid, "error": "Finns inte i papperskorgen"})
+                continue
+            try:
+                dest = self._restore_one(entry["original_path"], entry["stored_name"])
+                for sc in entry.get("sidecars", []):
+                    self._restore_one(sc["original_path"], sc["stored_name"])
+                keep = [e for e in keep if e["id"] != tid]
+                restored.append({"id": tid, "restored_path": str(dest)})
+            except Exception as e:
+                logger.exception("Failed to restore %s", tid)
+                errors.append({"id": tid, "error": str(e)})
+
+        self._rewrite_manifest(keep)
+        return {"restored": restored, "errors": errors}
+
+    def _restore_one(self, original_path: str, stored_name: str) -> Path:
+        """Move one stored file back to original_path, avoiding overwrite."""
+        dest = Path(original_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists():
+            dest = dest.with_name(f"{dest.stem}-restored{dest.suffix}")
+        shutil.move(str(TRASH_DIR / stored_name), str(dest))
+        return dest
+
+    def empty(self, ids: list[str] | None = None) -> dict:
+        """Permanently delete trashed files (all, or the given ids)."""
+        entries = self._load_manifest()
+        target_ids = set(ids) if ids else {e["id"] for e in entries}
+        keep: list[dict] = []
+        deleted = 0
+        for e in entries:
+            if e["id"] not in target_ids:
+                keep.append(e)
+                continue
+            for name in [e["stored_name"], *[sc["stored_name"] for sc in e.get("sidecars", [])]]:
+                try:
+                    (TRASH_DIR / name).unlink(missing_ok=True)
+                    deleted += 1
+                except Exception:
+                    logger.exception("Failed to delete trashed file %s", name)
+        self._rewrite_manifest(keep)
+        return {"deleted": deleted}
+
+
+culling_service = CullingService()

--- a/backend/api/services/culling_service.py
+++ b/backend/api/services/culling_service.py
@@ -238,7 +238,10 @@ class CullingService:
     def empty(self, ids: list[str] | None = None) -> dict:
         """Permanently delete trashed files (all, or the given ids)."""
         entries = self._load_manifest()
-        target_ids = set(ids) if ids else {e["id"] for e in entries}
+        # Distinguish omitted ids (None -> empty everything) from an explicit
+        # empty list ([] -> delete nothing); a falsy check would nuke the whole
+        # trash when a client forwards an empty selection.
+        target_ids = {e["id"] for e in entries} if ids is None else set(ids)
         keep: list[dict] = []
         deleted = 0
         for e in entries:

--- a/backend/api/services/culling_service.py
+++ b/backend/api/services/culling_service.py
@@ -9,6 +9,7 @@ Reuses the shared file resolution (file_resolver) + filename parsing
 filer2mappar for trashing. No face recognition — players are filename-derived.
 """
 
+import fnmatch
 import json
 import logging
 import shutil
@@ -48,12 +49,19 @@ class CullingService:
         date_from: str | None = None,
         date_to: str | None = None,
         player: str | None = None,
+        name_glob: str | None = None,
     ) -> dict:
-        """Resolve files and return parsed entries, optionally filtered to a player.
+        """Resolve files and return parsed entries, optionally filtered.
+
+        ``player`` keeps only files where that exact parsed name appears.
+        ``name_glob`` is a Finder-style, case-insensitive basename pattern
+        (e.g. ``*ArvidW*``) applied to the resolved files within the selected
+        folder(s) — it narrows the working set, it does not scan the filesystem.
 
         Returns {files: [{path, basename, names, datetime}], players: [name,...]}.
         ``players`` is the sorted set of names present across the resolved files
-        (for the filter dropdown). Raises ValueError when no input is given.
+        (for the filter dropdown, computed before name_glob so the dropdown stays
+        complete). Raises ValueError when no folder/glob input is given.
         """
         roots = roots or []
         globs = globs or []
@@ -70,11 +78,15 @@ class CullingService:
         )
         entries = build_entries(files)
 
+        glob_lower = name_glob.lower() if name_glob else None
+
         all_names: set[str] = set()
         out: list[dict] = []
         for dt, names, path in entries:
             all_names.update(names)
             if player is not None and player not in names:
+                continue
+            if glob_lower is not None and not fnmatch.fnmatch(Path(path).name.lower(), glob_lower):
                 continue
             out.append({
                 "path": path,
@@ -130,30 +142,36 @@ class CullingService:
             try:
                 tid = uuid.uuid4().hex
                 stored_name = f"{tid}__{src.name}"
+                # Move the main file first; only after this succeeds is the file
+                # gone from its folder, so the manifest entry below must always be
+                # written to keep it restorable.
                 shutil.move(str(src), str(TRASH_DIR / stored_name))
-
-                stored_sidecars: list[dict] = []
-                for sc in find_sidecar_files(src, SIDECAR_EXTENSIONS):
-                    sc_stored = f"{tid}__{sc.name}"
-                    shutil.move(str(sc), str(TRASH_DIR / sc_stored))
-                    stored_sidecars.append({
-                        "original_path": str(sc),
-                        "stored_name": sc_stored,
-                    })
-
-                entry = {
-                    "id": tid,
-                    "original_path": str(src),
-                    "stored_name": stored_name,
-                    "basename": src.name,
-                    "sidecars": stored_sidecars,
-                    "trashed_at": datetime.now().isoformat(),
-                }
-                self._append_manifest(entry)
-                trashed.append({"id": tid, "original_path": str(src), "basename": src.name})
             except Exception as e:
                 logger.exception("Failed to trash %s", p)
                 errors.append({"path": p, "error": str(e)})
+                continue
+
+            # Sidecars are best-effort: a locked/failed sidecar must not abort the
+            # manifest entry for the already-moved main file (else it'd be lost).
+            stored_sidecars: list[dict] = []
+            for sc in find_sidecar_files(src, SIDECAR_EXTENSIONS):
+                try:
+                    sc_stored = f"{tid}__{sc.name}"
+                    shutil.move(str(sc), str(TRASH_DIR / sc_stored))
+                    stored_sidecars.append({"original_path": str(sc), "stored_name": sc_stored})
+                except Exception:
+                    logger.exception("Failed to trash sidecar %s", sc)
+
+            entry = {
+                "id": tid,
+                "original_path": str(src),
+                "stored_name": stored_name,
+                "basename": src.name,
+                "sidecars": stored_sidecars,
+                "trashed_at": datetime.now().isoformat(),
+            }
+            self._append_manifest(entry)
+            trashed.append({"id": tid, "original_path": str(src), "basename": src.name})
 
         return {"trashed": trashed, "errors": errors}
 
@@ -194,11 +212,20 @@ class CullingService:
         return {"restored": restored, "errors": errors}
 
     def _restore_one(self, original_path: str, stored_name: str) -> Path:
-        """Move one stored file back to original_path, avoiding overwrite."""
-        dest = Path(original_path)
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        """Move one stored file back to original_path, never overwriting.
+
+        If the original path is taken, restore alongside as ``<stem>-restored``,
+        adding a numeric suffix until an unused name is found.
+        """
+        original = Path(original_path)
+        original.parent.mkdir(parents=True, exist_ok=True)
+        dest = original
         if dest.exists():
-            dest = dest.with_name(f"{dest.stem}-restored{dest.suffix}")
+            dest = original.with_name(f"{original.stem}-restored{original.suffix}")
+            counter = 2
+            while dest.exists():
+                dest = original.with_name(f"{original.stem}-restored-{counter}{original.suffix}")
+                counter += 1
         shutil.move(str(TRASH_DIR / stored_name), str(dest))
         return dest
 

--- a/backend/api/services/file_resolver.py
+++ b/backend/api/services/file_resolver.py
@@ -1,0 +1,137 @@
+"""Shared file resolver for folder/glob/date-span inputs.
+
+Resolves a set of root folders and/or glob patterns into a sorted, de-duplicated
+list of absolute file paths, applying a case-insensitive extension filter and an
+optional date span filtered on the *filename* date (YYMMDD_HHMMSS...).
+
+Reusable Tier-0 helper: GUI modules that take a folder/wildcard input bar (count
+players, organize files, rename, ...) all resolve their working set through here
+so globbing semantics stay consistent across features.
+"""
+
+import glob
+import os
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+# Backend root on sys.path so we can import the CLI parser (pattern used by the
+# other services, e.g. statistics_service).
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+from rakna_spelare import parse_filename  # noqa: E402
+
+from .rename_service import SUPPORTED_EXTENSIONS  # noqa: E402
+
+# App-managed trash (soft-deleted files live here). Resolution always skips it so
+# trashed files are never re-counted or re-listed by any feature. The culling
+# service is the writer; it imports TRASH_DIR from here.
+_DATA_HOME = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+TRASH_DIR = _DATA_HOME / "faceid" / "trash"
+
+# Extension presets. Values are lowercase extensions including the leading dot.
+# Matching against filenames is always case-insensitive.
+EXTENSION_PRESETS: dict[str, list[str]] = {
+    "jpg": [".jpg", ".jpeg"],
+    "nef": [".nef"],
+    "raw": [".nef", ".cr2", ".cr3", ".arw", ".dng", ".raw", ".raf", ".orf", ".rw2"],
+    "images": [".jpg", ".jpeg", ".png", ".tiff", ".tif"],
+    "all": list(SUPPORTED_EXTENSIONS),
+}
+
+
+def preset_extensions(preset: str | None) -> list[str]:
+    """Map a preset name to its lowercase extension list.
+
+    Unknown/empty preset -> [] (meaning: keep every file that parses).
+    """
+    if not preset:
+        return []
+    return EXTENSION_PRESETS.get(preset.lower(), [])
+
+
+def _parse_date_bound(value: str | None) -> date | None:
+    """Parse a date bound accepting YYMMDD, YYYY-MM-DD or YYYYMMDD. None passes through."""
+    if not value:
+        return None
+    value = value.strip()
+    for fmt in ("%Y-%m-%d", "%y%m%d", "%Y%m%d"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Ogiltigt datumformat: {value!r} (förväntar YYYY-MM-DD eller YYMMDD)")
+
+
+def _matches_extension(path: str, allowed_lower: set[str]) -> bool:
+    if not allowed_lower:
+        return True
+    return os.path.splitext(path)[1].lower() in allowed_lower
+
+
+def resolve_files(
+    roots: list[str] | None = None,
+    globs: list[str] | None = None,
+    extensions: list[str] | None = None,
+    recursive: bool = True,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> list[str]:
+    """Resolve roots + glob patterns into a sorted list of absolute file paths.
+
+    Args:
+        roots: directories to scan (each scanned recursively when recursive=True).
+        globs: shell glob patterns (``~`` is expanded), e.g. ``~/Pictures/250601*.jpg``.
+        extensions: lowercase extensions with leading dot to keep; empty/None = keep all.
+        recursive: when True, roots are walked recursively.
+        date_from / date_to: inclusive bounds on the filename date (YYMMDD / YYYY-MM-DD).
+            When either is set, files whose name does not parse to a date are dropped.
+
+    Returns:
+        Sorted, de-duplicated list of absolute file paths.
+    """
+    roots = roots or []
+    globs = globs or []
+    allowed_lower = {e.lower() for e in (extensions or [])}
+
+    d_from = _parse_date_bound(date_from)
+    d_to = _parse_date_bound(date_to)
+    date_filtering = d_from is not None or d_to is not None
+
+    trash_prefix = str(TRASH_DIR.resolve()) + os.sep
+
+    candidates: set[str] = set()
+
+    for pat in globs:
+        for match in glob.glob(os.path.expanduser(pat), recursive=recursive):
+            if os.path.isfile(match):
+                candidates.add(os.path.abspath(match))
+
+    for root in roots:
+        base = Path(os.path.expanduser(root))
+        if not base.is_dir():
+            continue
+        iterator = base.rglob("*") if recursive else base.glob("*")
+        for p in iterator:
+            if p.is_file():
+                candidates.add(str(p.resolve()))
+
+    result: list[str] = []
+    for path in candidates:
+        # Never surface soft-deleted files living in the app trash.
+        if path.startswith(trash_prefix):
+            continue
+        if not _matches_extension(path, allowed_lower):
+            continue
+        if date_filtering:
+            dt, _ = parse_filename(path)
+            if dt is None:
+                continue
+            d = dt.date()
+            if d_from is not None and d < d_from:
+                continue
+            if d_to is not None and d > d_to:
+                continue
+        result.append(path)
+
+    result.sort()
+    return result

--- a/backend/api/services/player_count_service.py
+++ b/backend/api/services/player_count_service.py
@@ -1,0 +1,112 @@
+"""Player Count Service
+
+GUI/API backing for the ``rakna_spelare.py`` CLI: resolve a folder/glob/date-span
+input into image files and count how many images each named person appears in,
+with over/under-representation statistics.
+
+Shares the counting core (``compute_player_stats``) with the CLI so the numbers
+never fork, and the file resolution with the shared ``file_resolver``.
+"""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Backend root on sys.path to import the CLI counting core (pattern shared with
+# the other services).
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from rakna_spelare import (  # noqa: E402
+    compute_player_stats,
+    load_exclusion_config,
+)
+
+from .file_resolver import preset_extensions, resolve_files  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+class PlayerCountService:
+    """Counts images per named person from resolved files."""
+
+    def _exclusion_sets(
+        self,
+        tranare: list[str] | None,
+        publik: list[str] | None,
+    ) -> tuple[set[str], set[str], set[str]]:
+        """Resolve coach/audience/group sets.
+
+        Per-request overrides take precedence; otherwise fall back to env +
+        config file (~/.local/share/faceid/rakna_spelare.json) via the CLI's
+        own loader. "Laget" is always treated as a group photo.
+        """
+        config = load_exclusion_config()
+
+        env_tranare = os.environ.get("RAKNA_TRANARE", "")
+        env_publik = os.environ.get("RAKNA_PUBLIK", "")
+        if env_tranare:
+            config["tranare"] = [n.strip() for n in env_tranare.split(",") if n.strip()]
+        if env_publik:
+            config["publik"] = [n.strip() for n in env_publik.split(",") if n.strip()]
+
+        tranare_set = set(tranare) if tranare is not None else set(config.get("tranare", []))
+        publik_set = set(publik) if publik is not None else set(config.get("publik", []))
+        grupp_set = {"Laget"}
+        return tranare_set, publik_set, grupp_set
+
+    def count(
+        self,
+        roots: list[str] | None = None,
+        globs: list[str] | None = None,
+        extension_preset: str | None = None,
+        extensions: list[str] | None = None,
+        recursive: bool = True,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        gap_minutes: int = 30,
+        baseline: str = "median",
+        min_images: int = 3,
+        per_match: bool = False,
+        tranare: list[str] | None = None,
+        publik: list[str] | None = None,
+    ) -> dict:
+        """Resolve files and compute player statistics.
+
+        Returns the dict from ``compute_player_stats`` plus ``files_resolved``.
+        Raises ValueError when no folder/glob input is given.
+        """
+        roots = roots or []
+        globs = globs or []
+        if not roots and not globs:
+            raise ValueError("Ange minst en mapp eller ett glob-mönster.")
+
+        # Explicit extensions win over the preset; preset 'all'/None keeps everything.
+        ext_list = extensions if extensions else preset_extensions(extension_preset)
+
+        files = resolve_files(
+            roots=roots,
+            globs=globs,
+            extensions=ext_list,
+            recursive=recursive,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+        tranare_set, publik_set, grupp_set = self._exclusion_sets(tranare, publik)
+
+        stats = compute_player_stats(
+            files,
+            gap_minutes=gap_minutes,
+            baseline_method=baseline,
+            min_images=min_images,
+            tranare_set=tranare_set,
+            publik_set=publik_set,
+            grupp_set=grupp_set,
+            per_match=per_match,
+        )
+        stats["files_resolved"] = len(files)
+        return stats
+
+
+player_count_service = PlayerCountService()

--- a/backend/rakna_spelare.py
+++ b/backend/rakna_spelare.py
@@ -110,6 +110,237 @@ def compute_baseline(counts: list[int], method: str = "median") -> float:
     return median(counts) if method == "median" else mean(counts)
 
 
+# ============================================================================
+# Reusable counting core (shared by the CLI and the GUI/API).
+#
+# These functions produce plain data (lists/dicts of primitives) and never
+# print. The terminal renderers (render_bar/render_spark/print_section) consume
+# the same parsed entries but format for the console; the API consumes the dicts
+# from compute_player_stats() and renders its own visuals.
+# ============================================================================
+
+
+def build_entries(files: list[str]) -> list[tuple[datetime, list[str], str]]:
+    """Parse + filter + sort files into (datetime, names, filename) entries.
+
+    Files whose name does not match the YYMMDD_HHMMSS[_Name...] format are
+    silently skipped (parse_filename returns None). Sorted by timestamp.
+    """
+    entries: list[tuple[datetime, list[str], str]] = []
+    for fn in files:
+        dt, names = parse_filename(fn)
+        if dt is None:
+            continue
+        entries.append((dt, names or [], fn))
+    entries.sort(key=lambda x: x[0])
+    return entries
+
+
+def segment_matches(
+    entries: list[tuple[datetime, list[str], str]], gap_minutes: int
+) -> list[list[int]]:
+    """Group temporally-adjacent entries into matches.
+
+    A new match starts whenever the gap to the previous entry exceeds
+    gap_minutes. Returns a list of matches, each a list of indices into entries.
+    """
+    if not entries:
+        return []
+    matches: list[list[int]] = []
+    current = [0]
+    for i in range(1, len(entries)):
+        if entries[i][0] - entries[i - 1][0] > timedelta(minutes=gap_minutes):
+            matches.append(current)
+            current = [i]
+        else:
+            current.append(i)
+    matches.append(current)
+    return matches
+
+
+def bucket_counter(
+    counter: Counter,
+    min_images: int,
+    tranare_set: set[str],
+    publik_set: set[str],
+    grupp_set: set[str],
+) -> dict[str, dict[str, int]]:
+    """Split a name->count Counter into the five output buckets.
+
+    Returns dict with keys: players, below_threshold, tranare, publik, grupp.
+    """
+    excluded = tranare_set | publik_set | grupp_set
+    return {
+        "players": {n: c for n, c in counter.items() if n not in excluded and c >= min_images},
+        "below_threshold": {n: c for n, c in counter.items() if n not in excluded and c < min_images},
+        "tranare": {n: c for n, c in counter.items() if n in tranare_set},
+        "publik": {n: c for n, c in counter.items() if n in publik_set},
+        "grupp": {n: c for n, c in counter.items() if n in grupp_set},
+    }
+
+
+def classify_deviation(delta_pct: float) -> str:
+    """Machine-readable deviation level matching the CLI color thresholds.
+
+    Mirrors get_deviation_color: abs>20 -> "high", abs>10 -> "warn", else "ok".
+    """
+    abs_pct = abs(delta_pct)
+    if abs_pct > 20:
+        return "high"
+    if abs_pct > 10:
+        return "warn"
+    return "ok"
+
+
+def summarize_counter(
+    counter: Counter,
+    timestamps_per_person: dict[str, list[datetime]],
+    total_images: int,
+    min_images: int,
+    baseline_method: str,
+    tranare_set: set[str],
+    publik_set: set[str],
+    grupp_set: set[str],
+) -> dict:
+    """Produce a JSON-serializable summary for one counter (total or per match).
+
+    Players are sorted by (count - baseline) descending, same as the CLI table.
+    Excluded groups (tranare/publik/grupp/below_threshold) are sorted by count.
+    """
+    buckets = bucket_counter(counter, min_images, tranare_set, publik_set, grupp_set)
+    players_counts = buckets["players"]
+    baseline = compute_baseline(list(players_counts.values()), baseline_method) if players_counts else 0
+
+    def player_row(name: str, count: int) -> dict:
+        pct = 100 * count / total_images if total_images > 0 else 0
+        delta_n = count - baseline
+        delta_pct = 100 * delta_n / baseline if baseline > 0 else 0
+        return {
+            "name": name,
+            "count": count,
+            "pct": round(pct, 1),
+            "delta_n": round(delta_n, 1),
+            "delta_pct": round(delta_pct, 1),
+            "level": classify_deviation(delta_pct),
+            "timestamps": [ts.isoformat() for ts in timestamps_per_person.get(name, [])],
+        }
+
+    players = [
+        player_row(n, c)
+        for n, c in sorted(players_counts.items(), key=lambda x: x[1] - baseline, reverse=True)
+    ]
+
+    def excluded_rows(group: dict[str, int]) -> list[dict]:
+        return [
+            {
+                "name": n,
+                "count": c,
+                "pct": round(100 * c / total_images, 1) if total_images > 0 else 0,
+            }
+            for n, c in sorted(group.items(), key=lambda x: x[1], reverse=True)
+        ]
+
+    return {
+        "baseline": round(baseline, 1),
+        "baseline_method": baseline_method,
+        "players": players,
+        "excluded": {
+            "tranare": excluded_rows(buckets["tranare"]),
+            "publik": excluded_rows(buckets["publik"]),
+            "grupp": excluded_rows(buckets["grupp"]),
+            "below_threshold": excluded_rows(buckets["below_threshold"]),
+        },
+    }
+
+
+def compute_player_stats(
+    files: list[str],
+    gap_minutes: int = 30,
+    baseline_method: str = "median",
+    min_images: int = 3,
+    tranare_set: set[str] | None = None,
+    publik_set: set[str] | None = None,
+    grupp_set: set[str] | None = None,
+    per_match: bool = False,
+) -> dict:
+    """Top-level counting core: files -> JSON-serializable statistics.
+
+    Returns {total_images, time_range, ...summary, matches: [...]} or
+    {total_images: 0, ...empty...} when nothing parsed. Shared by the GUI/API;
+    the CLI uses build_entries/segment_matches directly for its rendering.
+    """
+    tranare_set = tranare_set or set()
+    publik_set = publik_set or set()
+    grupp_set = grupp_set or set()
+
+    entries = build_entries(files)
+    if not entries:
+        return {
+            "total_images": 0,
+            "time_range": None,
+            "baseline": 0,
+            "baseline_method": baseline_method,
+            "players": [],
+            "excluded": {"tranare": [], "publik": [], "grupp": [], "below_threshold": []},
+            "matches": [],
+        }
+
+    matches = segment_matches(entries, gap_minutes)
+
+    total_counter: Counter = Counter()
+    total_timestamps: dict[str, list[datetime]] = defaultdict(list)
+    for dt, names, _ in entries:
+        for n in names:
+            total_counter[n] += 1
+            total_timestamps[n].append(dt)
+
+    total_images = len(entries)
+    global_start = entries[0][0]
+    global_end = entries[-1][0]
+    duration_minutes = (global_end - global_start).total_seconds() / 60
+
+    summary = summarize_counter(
+        total_counter, total_timestamps, total_images, min_images, baseline_method,
+        tranare_set, publik_set, grupp_set,
+    )
+
+    match_summaries: list[dict] = []
+    if per_match:
+        for match_idx, idx_list in enumerate(matches, start=1):
+            c: Counter = Counter()
+            ts_map: dict[str, list[datetime]] = defaultdict(list)
+            for idx in idx_list:
+                dt, names, _ = entries[idx]
+                for n in names:
+                    c[n] += 1
+                    ts_map[n].append(dt)
+            m_start = entries[idx_list[0]][0]
+            m_end = entries[idx_list[-1]][0]
+            m_summary = summarize_counter(
+                c, ts_map, len(idx_list), min_images, baseline_method,
+                tranare_set, publik_set, grupp_set,
+            )
+            match_summaries.append({
+                "index": match_idx,
+                "start": m_start.isoformat(),
+                "end": m_end.isoformat(),
+                "duration_minutes": round((m_end - m_start).total_seconds() / 60, 1),
+                "total_images": len(idx_list),
+                **m_summary,
+            })
+
+    return {
+        "total_images": total_images,
+        "time_range": {
+            "start": global_start.isoformat(),
+            "end": global_end.isoformat(),
+            "duration_minutes": round(duration_minutes, 1),
+        },
+        **summary,
+        "matches": match_summaries,
+    }
+
+
 def render_bar(value: int, baseline: float, width: int = 20, ascii_mode: bool = False) -> str:
     """Render a progress bar showing value relative to baseline."""
     if baseline <= 0:
@@ -298,13 +529,13 @@ def print_section(
     tranare_set = tranare_set or set()
     publik_set = publik_set or set()
     grupp_set = grupp_set or set()
-    excluded = tranare_set | publik_set | grupp_set
 
-    players = {n: c for n, c in counter.items() if n not in excluded and c >= min_images}
-    below_threshold = {n: c for n, c in counter.items() if n not in excluded and c < min_images}
-    tranare = {n: c for n, c in counter.items() if n in tranare_set}
-    publik = {n: c for n, c in counter.items() if n in publik_set}
-    grupp = {n: c for n, c in counter.items() if n in grupp_set}
+    buckets = bucket_counter(counter, min_images, tranare_set, publik_set, grupp_set)
+    players = buckets["players"]
+    below_threshold = buckets["below_threshold"]
+    tranare = buckets["tranare"]
+    publik = buckets["publik"]
+    grupp = buckets["grupp"]
 
     baseline_counts = list(players.values())
     baseline = compute_baseline(baseline_counts, baseline_method) if baseline_counts else 0
@@ -404,30 +635,13 @@ def main(args: argparse.Namespace) -> None:
         print("Ingen fil matchade angivet mönster.")
         sys.exit(1)
 
-    entries = []
-    for fn in files:
-        dt, names = parse_filename(fn)
-        if dt is None:
-            continue
-        entries.append((dt, names, fn))
+    entries = build_entries(files)
 
     if not entries:
         print("Inga giltiga bilder hittades bland matchande filer.")
         sys.exit(1)
 
-    entries.sort(key=lambda x: x[0])
-
-    matcher = []
-    current_match = [0]
-    for i in range(1, len(entries)):
-        prev_dt = entries[i - 1][0]
-        this_dt = entries[i][0]
-        if this_dt - prev_dt > timedelta(minutes=args.gap_minutes):
-            matcher.append(current_match)
-            current_match = [i]
-        else:
-            current_match.append(i)
-    matcher.append(current_match)
+    matcher = segment_matches(entries, args.gap_minutes)
 
     total_counter = Counter()
     total_timestamps = defaultdict(list)

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -620,6 +620,119 @@ Remove ALL dlib (128-dim) encodings. dlib backend is deprecated.
 
 ---
 
+## Player Count
+
+Counts images per named player from filenames (no face recognition; the
+filename format `YYMMDD_HHMMSS[-N]_Name1,_Name2.ext` is parsed). Backs the
+**Räkna spelare** module.
+
+### `POST /api/v1/players/count`
+
+Resolve a folder/glob/date selection and return per-player counts with
+median-baseline over/under-representation statistics.
+
+**Request:**
+```json
+{
+  "roots": ["/path/to/folder"],
+  "globs": ["~/Pictures/250601*.jpg"],
+  "extension_preset": "jpg",
+  "extensions": null,
+  "recursive": true,
+  "date_from": "2025-06-01",
+  "date_to": "2025-06-01",
+  "gap_minutes": 30,
+  "baseline": "median",
+  "min_images": 3,
+  "per_match": false,
+  "tranare": null,
+  "publik": null
+}
+```
+
+`extension_preset` is one of `jpg` (jpg/jpeg), `nef`, `raw`, `images`, `all`
+(case-insensitive); `extensions` overrides it with an explicit list. `date_from`/
+`date_to` accept `YYYY-MM-DD` or `YYMMDD` and filter on the filename date.
+At least one of `roots`/`globs` is required.
+
+**Response:**
+```json
+{
+  "total_images": 120,
+  "time_range": { "start": "2025-06-01T10:00:00", "end": "2025-06-01T12:30:00", "duration_minutes": 150.0 },
+  "baseline": 8.0,
+  "baseline_method": "median",
+  "players": [
+    { "name": "Anna", "count": 10, "pct": 8.3, "delta_n": 2.0, "delta_pct": 25.0, "level": "high", "timestamps": ["2025-06-01T10:00:00"] }
+  ],
+  "excluded": {
+    "tranare": [], "publik": [], "grupp": [{ "name": "Laget", "count": 3, "pct": 2.5 }],
+    "below_threshold": [{ "name": "Cesar", "count": 2, "pct": 1.7 }]
+  },
+  "matches": [],
+  "files_resolved": 123
+}
+```
+
+`level` is `ok`/`warn`/`high` (mirrors the CLI ±10/±20 % thresholds). `matches`
+is populated only when `per_match` is true.
+
+---
+
+## Culling
+
+Backs the **Gallra spelare** module: list a player's JPEGs and soft-delete /
+restore them via an app-managed trash (`~/.local/share/faceid/trash/`, manifest-
+backed). Trashed files are automatically excluded from listing and counting.
+
+### `POST /api/v1/culling/files`
+
+List image files for the current filter. `player` is an exact parsed-name
+filter; `name_glob` is a case-insensitive Finder-style basename pattern
+(e.g. `*ArvidW*`) applied to the resolved files. Other fields match
+`/players/count`.
+
+**Response:**
+```json
+{
+  "files": [
+    { "path": "/path/250601_100000_Anna.jpg", "basename": "250601_100000_Anna.jpg", "names": ["Anna"], "datetime": "2025-06-01T10:00:00" }
+  ],
+  "players": ["Anna", "Bertil"]
+}
+```
+
+`players` lists every name present across the resolved files (computed before
+the `name_glob`/`player` filter, so the dropdown stays complete).
+
+### `POST /api/v1/culling/trash`
+
+Move files (and their `.xmp` sidecars) to the app trash.
+
+**Request:** `{ "paths": ["/path/250601_100000_Anna.jpg"] }`
+
+**Response:** `{ "trashed": [{ "id": "…", "original_path": "…", "basename": "…" }], "errors": [] }`
+
+### `GET /api/v1/culling/trash`
+
+List the items currently in the trash: `{ "items": [{ "id", "original_path", "basename", "sidecars", "trashed_at" }] }`.
+
+### `POST /api/v1/culling/restore`
+
+Restore trashed items to their original location. Never overwrites: if the
+original path is occupied, the file is restored as `<stem>-restored<ext>` (and
+sidecars follow it).
+
+**Request:** `{ "ids": ["…"] }`
+**Response:** `{ "restored": [{ "id": "…", "restored_path": "…" }], "errors": [] }`
+
+### `POST /api/v1/culling/empty`
+
+Permanently delete trashed items. `{ "ids": [...] }` deletes those ids; omit
+`ids` to empty the whole trash. Response: `{ "deleted": <count> }`.
+
+---
+
 ## WebSocket
 
 ### `ws://127.0.0.1:5001/ws/progress`

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -18,6 +18,8 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 | **Log Viewer** | Visa loggar |
 | **Original View** | Jämför med originalfil |
 | **Statistics** | Bearbetningsstatistik |
+| **Räkna spelare** | Räknar bilder per spelare (från filnamn) med över-/underrepresentation |
+| **Gallra spelare** | Gallra bilder per spelare med förhandsvisning och papperskorg |
 | **Database** | Databashantering |
 | **Preferences** | Inställningar |
 | **Theme Editor** | Anpassa utseende |
@@ -74,12 +76,22 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 | `Cmd+Shift+]` | Lägg till kolumn |
 | `Cmd+Shift+[` | Ta bort kolumn |
 
+### Gallring (Gallra spelare)
+
+| Genväg | Funktion |
+|--------|----------|
+| `↑` / `↓` (`k` / `j`) | Föregående/nästa bild i listan |
+| `x` / `Delete` | Flytta bilden till papperskorgen och gå vidare |
+| `Cmd+Z` | Ångra (återställ senast gallrade bild) |
+
 ### Allmänt
 
 | Genväg | Funktion |
 |--------|----------|
 | `?` | Visa hjälp |
 | `Cmd+O` | Öppna fil |
+| `Cmd+Shift+K` | Räkna spelare |
+| `Cmd+Shift+G` | Gallra spelare |
 | `Cmd+,` | Inställningar |
 | `Cmd+S` | Spara ändringar |
 
@@ -121,6 +133,22 @@ antal.
 1. När filer är granskade, klicka **Rename** i File Queue
 2. Bekräfta namnbytet
 3. Filer får nya namn enligt mönstret `YYMMDD_HHMMSS_Namn1,_Namn2.NEF`
+
+### 5. Räkna och gallra spelare (på utvecklade jpg)
+
+1. Öppna **Räkna spelare** (`Cmd+Shift+K`). Ange en mapp och/eller ett wildcard
+   i balken högst upp, välj filtyp (vanligen `jpg / jpeg`) och ev. datum-span,
+   och klicka **Räkna**. Tabellen visar antal bilder per spelare och avvikelse
+   från medianen (grön/gul/röd). Statistiken uppdateras automatiskt när filer
+   läggs till, tas bort eller byter namn i mappen.
+2. Klicka på en spelare i tabellen för att öppna **Gallra spelare**
+   (`Cmd+Shift+G`) filtrerad på den spelaren. Filtret kan finjusteras med
+   spelar-menyn eller ett eget glob (t.ex. `*ArvidW*`) i balken.
+3. Bläddra i fillistan till vänster (`↑`/`↓`); bilden visas maximerad till höger.
+   Tryck `x` (eller `Delete`) för att flytta bilden till papperskorgen och gå
+   vidare. `Cmd+Z` ångrar.
+4. Papperskorgen (knappen **Papperskorg**) listar gallrade bilder och återställer
+   dem till ursprungsplatsen, eller tömmer permanent.
 
 ---
 

--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -762,6 +762,12 @@ const FOLDER_DEBOUNCE_MS = 300;
 ipcMain.on("watch-folder", (event, { dir, recursive = true } = {}) => {
   if (!dir) return;
 
+  // Expand a leading ~ - glob inputs like ~/Pictures/... arrive un-expanded, and
+  // fs.existsSync/fs.watch don't expand it (so the watch would silently no-op).
+  if (dir.startsWith("~")) {
+    dir = path.join(os.homedir(), dir.slice(1));
+  }
+
   const existing = folderWatchers.get(dir);
   if (existing) {
     existing.refs += 1;
@@ -772,13 +778,26 @@ ipcMain.on("watch-folder", (event, { dir, recursive = true } = {}) => {
     if (!fs.existsSync(dir)) return;
 
     const entry = { watcher: null, refs: 1, timer: null };
-    const watcher = fs.watch(dir, { recursive }, () => {
+    const onChange = () => {
       if (entry.timer) clearTimeout(entry.timer);
       entry.timer = setTimeout(() => {
         entry.timer = null;
         mainWindow?.webContents.send("folder-changed", dir);
       }, FOLDER_DEBOUNCE_MS);
-    });
+    };
+    let watcher;
+    try {
+      watcher = fs.watch(dir, { recursive }, onChange);
+    } catch (err) {
+      // Recursive watching is unsupported on Linux (ERR_FEATURE_UNAVAILABLE_ON_PLATFORM);
+      // fall back to a non-recursive watch so top-level changes still refresh.
+      if (recursive) {
+        console.warn("[Main] Recursive folder watch unavailable, falling back:", err.message);
+        watcher = fs.watch(dir, { recursive: false }, onChange);
+      } else {
+        throw err;
+      }
+    }
 
     watcher.on("error", (err) => {
       console.error("[Main] Folder watcher error:", dir, err.message);
@@ -799,6 +818,11 @@ ipcMain.on("watch-folder", (event, { dir, recursive = true } = {}) => {
 });
 
 ipcMain.on("unwatch-folder", (event, dir) => {
+  if (!dir) return;
+  // Match the ~-expansion done in watch-folder so we find the right watcher.
+  if (dir.startsWith("~")) {
+    dir = path.join(os.homedir(), dir.slice(1));
+  }
   const entry = folderWatchers.get(dir);
   if (!entry) return;
 

--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -737,4 +737,81 @@ ipcMain.on("unwatch-all-files", () => {
   fileToDirectory.clear();
 });
 
+// Folder selection that returns the chosen directory paths themselves (not the
+// expanded image files) - used by modules that let the backend do the globbing.
+ipcMain.handle("open-folder-paths", async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    properties: ["openDirectory", "multiSelections"],
+    message: "Välj mapp(ar)",
+  });
+
+  if (result.canceled || !result.filePaths || result.filePaths.length === 0) {
+    return null;
+  }
+  return result.filePaths;
+});
+
+// Folder-level watching for live auto-refresh. Unlike the file-list watcher
+// above, this watches a whole directory (optionally recursively) and emits on
+// ANY add/remove/rename/change, debounced to coalesce the bursts fs.watch fires
+// on macOS. Keyed by folder path; reference-counted so multiple modules can
+// share a watcher.
+const folderWatchers = new Map(); // dir -> { watcher, refs, timer }
+const FOLDER_DEBOUNCE_MS = 300;
+
+ipcMain.on("watch-folder", (event, { dir, recursive = true } = {}) => {
+  if (!dir) return;
+
+  const existing = folderWatchers.get(dir);
+  if (existing) {
+    existing.refs += 1;
+    return;
+  }
+
+  try {
+    if (!fs.existsSync(dir)) return;
+
+    const entry = { watcher: null, refs: 1, timer: null };
+    const watcher = fs.watch(dir, { recursive }, () => {
+      if (entry.timer) clearTimeout(entry.timer);
+      entry.timer = setTimeout(() => {
+        entry.timer = null;
+        mainWindow?.webContents.send("folder-changed", dir);
+      }, FOLDER_DEBOUNCE_MS);
+    });
+
+    watcher.on("error", (err) => {
+      console.error("[Main] Folder watcher error:", dir, err.message);
+      if (entry.timer) clearTimeout(entry.timer);
+      try {
+        entry.watcher?.close();
+      } catch (_) {
+        // already closed
+      }
+      folderWatchers.delete(dir);
+    });
+
+    entry.watcher = watcher;
+    folderWatchers.set(dir, entry);
+  } catch (err) {
+    console.error("[Main] Failed to watch folder:", dir, err.message);
+  }
+});
+
+ipcMain.on("unwatch-folder", (event, dir) => {
+  const entry = folderWatchers.get(dir);
+  if (!entry) return;
+
+  entry.refs -= 1;
+  if (entry.refs > 0) return;
+
+  if (entry.timer) clearTimeout(entry.timer);
+  try {
+    entry.watcher?.close();
+  } catch (_) {
+    // already closed
+  }
+  folderWatchers.delete(dir);
+});
+
 console.log("[Main] Workspace mode initialized");

--- a/frontend/src/main/menu.js
+++ b/frontend/src/main/menu.js
@@ -285,6 +285,20 @@ function createApplicationMenu(mainWindow) {
           }
         },
         {
+          label: 'Räkna spelare',
+          accelerator: 'CmdOrCtrl+Shift+K',
+          click: () => {
+            sendMenuCommand('open-player-count');
+          }
+        },
+        {
+          label: 'Gallra spelare',
+          accelerator: 'CmdOrCtrl+Shift+G',
+          click: () => {
+            sendMenuCommand('open-culling');
+          }
+        },
+        {
           label: 'Database Management',
           accelerator: 'CmdOrCtrl+Shift+D',
           click: () => {

--- a/frontend/src/preload/preload.js
+++ b/frontend/src/preload/preload.js
@@ -27,6 +27,7 @@ contextBridge.exposeInMainWorld("ansiktenAPI", {
       "open-file-dialog",
       "open-multi-file-dialog",
       "open-folder-dialog",
+      "open-folder-paths",
       "expand-glob",
       "check-file-changed",
       "get-initial-file"
@@ -73,5 +74,22 @@ contextBridge.exposeInMainWorld("ansiktenAPI", {
 
   unwatchAllFiles: () => {
     ipcRenderer.send("unwatch-all-files");
+  },
+
+  // Folder-level watching for live auto-refresh (whole directory, debounced).
+  watchFolder: (dir, recursive = true) => {
+    ipcRenderer.send("watch-folder", { dir, recursive });
+  },
+
+  unwatchFolder: (dir) => {
+    ipcRenderer.send("unwatch-folder", dir);
+  },
+
+  onFolderChanged: (callback) => {
+    const handler = (event, dir) => callback(dir);
+    ipcRenderer.on("folder-changed", handler);
+    return () => {
+      ipcRenderer.removeListener("folder-changed", handler);
+    };
   },
 });

--- a/frontend/src/renderer/components/CullingModule.css
+++ b/frontend/src/renderer/components/CullingModule.css
@@ -1,0 +1,166 @@
+.culling {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.culling-filterbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  flex-wrap: wrap;
+}
+
+.culling-glob {
+  flex: 1 1 200px;
+  min-width: 140px;
+}
+
+.culling-spacer {
+  flex: 1;
+}
+
+.culling-roots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.culling-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  border-radius: 12px;
+  background: var(--bg-tertiary, var(--bg-primary));
+  border: 1px solid var(--border-color);
+  font-size: 0.8em;
+}
+
+.culling-chip-x {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+/* Two-column resizable body */
+.culling-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.culling-list {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  border-right: 1px solid var(--border-color);
+  overflow: hidden;
+}
+
+.culling-list-header {
+  padding: 6px 10px;
+  font-size: 0.85em;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.culling-files {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.culling-files li {
+  padding: 4px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+}
+
+.culling-files li:hover {
+  background: var(--bg-secondary);
+}
+
+.culling-files li.active {
+  background: var(--accent, #3b82f6);
+  color: #fff;
+}
+
+.culling-divider {
+  width: 5px;
+  cursor: col-resize;
+  background: var(--border-color);
+  flex: 0 0 auto;
+}
+
+.culling-divider:hover {
+  background: var(--accent, #3b82f6);
+}
+
+.culling-preview {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-primary);
+  overflow: hidden;
+}
+
+.culling-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+/* Trash view */
+.culling-trashview {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.culling-trash-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  font-size: 0.9em;
+  color: var(--text-secondary);
+}
+
+.culling-trash-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.culling-trash-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.85em;
+}
+
+.culling-trash-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -61,9 +61,12 @@ export function CullingModule({ node }) {
       recursive,
       date_from: dateFrom,
       date_to: dateTo,
+      // Exact player filter (from the dropdown / stats hand-off) so substring
+      // names can't conflate players; name_glob is the extra editable refinement.
+      player: player || null,
       name_glob: glob.trim() || null,
     }),
-    [roots, carriedGlobs, recursive, dateFrom, dateTo, glob]
+    [roots, carriedGlobs, recursive, dateFrom, dateTo, player, glob]
   );
 
   // ----- folder watching (live refresh) ------------------------------
@@ -178,6 +181,7 @@ export function CullingModule({ node }) {
         recursive: nextRecursive,
         date_from: nextFrom,
         date_to: nextTo,
+        player: data.name || null,
         name_glob: data.name ? `*${data.name}*` : null,
       };
       lastQueryRef.current = query;
@@ -207,7 +211,14 @@ export function CullingModule({ node }) {
     try {
       const res = await api.post('/api/v1/culling/trash', { paths: [victim.path] });
       const id = res.trashed?.[0]?.id;
-      if (id) undoStackRef.current.push(id);
+      if (id) {
+        undoStackRef.current.push(id);
+      } else {
+        // 200 with errors[] (permission/lock/race): the file is still on disk, so
+        // roll the optimistic removal back by reloading and surface the reason.
+        setError(res.errors?.[0]?.error || 'Kunde inte flytta filen till papperskorgen.');
+        if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+      }
     } catch (err) {
       setError(err.message || String(err));
       // Re-fetch to recover correct state on failure.

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -1,0 +1,417 @@
+/**
+ * CullingModule - Stats-driven culling/balancing workspace.
+ *
+ * Pick a player (or type a Finder-style glob), preview their JPEGs, and trash the
+ * weak ones recoverably until each player is balanced against the others. Layout:
+ * a full-width filter bar on top, then a resizable two-column row - file list on
+ * the left, the selected image maximized on the right.
+ *
+ * Trashing is reversible (app-managed trash + restore). Works on JPEGs over
+ * file://, so no NEF/RAW pipeline is needed.
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useBackend } from '../context/BackendContext.jsx';
+import { useModuleEvent } from '../hooks/useModuleEvent.js';
+import './CullingModule.css';
+
+const REFRESH_DEBOUNCE_MS = 400;
+
+export function CullingModule({ node }) {
+  const { api } = useBackend();
+
+  const [roots, setRoots] = useState([]);
+  const [glob, setGlob] = useState('');
+  const [player, setPlayer] = useState('');
+  const [players, setPlayers] = useState([]);
+
+  const [files, setFiles] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasRun, setHasRun] = useState(false);
+
+  const [showTrash, setShowTrash] = useState(false);
+  const [trashItems, setTrashItems] = useState([]);
+
+  const [leftWidthPct, setLeftWidthPct] = useState(32);
+
+  // Latest filter params for auto-refresh; undo stack of trashed ids.
+  const lastQueryRef = useRef(null);
+  const undoStackRef = useRef([]);
+  const watchedDirsRef = useRef(new Set());
+  const debounceRef = useRef(null);
+  const bodyRef = useRef(null);
+
+  const buildQuery = useCallback(
+    () => ({
+      roots,
+      globs: glob.trim() ? [glob.trim()] : [],
+      extension_preset: 'jpg',
+      recursive: true,
+      player: player || null,
+    }),
+    [roots, glob, player]
+  );
+
+  // ----- folder watching (live refresh) ------------------------------
+  const watchDirs = useCallback(() => {
+    const dirs = new Set(roots);
+    const g = glob.trim();
+    if (g) {
+      const base = globBaseDir(g);
+      if (base) dirs.add(base);
+    }
+    return dirs;
+  }, [roots, glob]);
+
+  const updateWatches = useCallback((desired) => {
+    const current = watchedDirsRef.current;
+    for (const dir of current) {
+      if (!desired.has(dir)) window.ansiktenAPI.unwatchFolder?.(dir);
+    }
+    for (const dir of desired) {
+      if (!current.has(dir)) window.ansiktenAPI.watchFolder?.(dir, true);
+    }
+    watchedDirsRef.current = desired;
+  }, []);
+
+  // ----- listing ------------------------------------------------------
+  const loadList = useCallback(
+    async (query, { keepIndex = false } = {}) => {
+      setIsLoading(true);
+      try {
+        const data = await api.post('/api/v1/culling/files', query);
+        setFiles(data.files);
+        setPlayers(data.players);
+        setError(null);
+        setCurrentIndex((prev) => {
+          if (data.files.length === 0) return -1;
+          if (keepIndex && prev >= 0) return Math.min(prev, data.files.length - 1);
+          return 0;
+        });
+      } catch (err) {
+        setError(err.message || String(err));
+      } finally {
+        setIsLoading(false);
+        setHasRun(true);
+      }
+    },
+    [api]
+  );
+
+  const runFilter = useCallback(() => {
+    const query = buildQuery();
+    lastQueryRef.current = query;
+    loadList(query);
+    updateWatches(watchDirs());
+  }, [buildQuery, loadList, updateWatches, watchDirs]);
+
+  // Auto-refresh on folder change.
+  useEffect(() => {
+    const unsubscribe = window.ansiktenAPI.onFolderChanged?.(() => {
+      if (!lastQueryRef.current) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        loadList(lastQueryRef.current, { keepIndex: true });
+      }, REFRESH_DEBOUNCE_MS);
+    });
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (unsubscribe) unsubscribe();
+      for (const dir of watchedDirsRef.current) window.ansiktenAPI.unwatchFolder?.(dir);
+      watchedDirsRef.current = new Set();
+    };
+  }, [loadList]);
+
+  // ----- filter bar actions ------------------------------------------
+  const addFolders = useCallback(async () => {
+    try {
+      const paths = await window.ansiktenAPI.invoke('open-folder-paths');
+      if (paths && paths.length) setRoots((r) => Array.from(new Set([...r, ...paths])));
+    } catch (err) {
+      console.error('[Culling] folder pick failed', err);
+    }
+  }, []);
+
+  const selectPlayer = useCallback((name) => {
+    setPlayer(name);
+    setGlob(name ? `*${name}*` : '');
+  }, []);
+
+  // Open filtered to a player from the stats module.
+  useModuleEvent(
+    'cull-player',
+    (data) => {
+      if (!data) return;
+      if (data.roots) setRoots(data.roots);
+      if (data.name) {
+        setPlayer(data.name);
+        setGlob(`*${data.name}*`);
+      }
+      const query = {
+        roots: data.roots || roots,
+        globs: [],
+        extension_preset: 'jpg',
+        recursive: true,
+        player: data.name || null,
+      };
+      lastQueryRef.current = query;
+      loadList(query);
+      updateWatches(new Set(data.roots || roots));
+    },
+    [roots, loadList, updateWatches]
+  );
+
+  // ----- cull loop ----------------------------------------------------
+  const trashCurrent = useCallback(async () => {
+    if (currentIndex < 0 || currentIndex >= files.length) return;
+    const victim = files[currentIndex];
+    // Optimistic: drop from list, advance.
+    setFiles((prev) => prev.filter((_, i) => i !== currentIndex));
+    setCurrentIndex((prev) => {
+      const nextLen = files.length - 1;
+      if (nextLen === 0) return -1;
+      return Math.min(prev, nextLen - 1);
+    });
+    try {
+      const res = await api.post('/api/v1/culling/trash', { paths: [victim.path] });
+      const id = res.trashed?.[0]?.id;
+      if (id) undoStackRef.current.push(id);
+    } catch (err) {
+      setError(err.message || String(err));
+      // Re-fetch to recover correct state on failure.
+      if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+    }
+  }, [api, currentIndex, files, loadList]);
+
+  const undoTrash = useCallback(async () => {
+    const id = undoStackRef.current.pop();
+    if (!id) return;
+    try {
+      await api.post('/api/v1/culling/restore', { ids: [id] });
+      if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+    } catch (err) {
+      setError(err.message || String(err));
+    }
+  }, [api, loadList]);
+
+  // ----- keyboard ----------------------------------------------------
+  useEffect(() => {
+    const handler = (e) => {
+      if (node && !node.isVisible?.()) return;
+      const tag = e.target?.tagName;
+      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+      if (showTrash) return;
+
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        undoTrash();
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      if (e.key === 'ArrowDown' || e.key === 'j') {
+        e.preventDefault();
+        setCurrentIndex((i) => Math.min(i + 1, files.length - 1));
+      } else if (e.key === 'ArrowUp' || e.key === 'k') {
+        e.preventDefault();
+        setCurrentIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === 'Delete' || e.key === 'Backspace' || e.key.toLowerCase() === 'x') {
+        e.preventDefault();
+        trashCurrent();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [node, files.length, showTrash, trashCurrent, undoTrash]);
+
+  // ----- trash view --------------------------------------------------
+  const openTrash = useCallback(async () => {
+    setShowTrash(true);
+    try {
+      const data = await api.get('/api/v1/culling/trash');
+      setTrashItems(data.items || []);
+    } catch (err) {
+      setError(err.message || String(err));
+    }
+  }, [api]);
+
+  const restoreItem = useCallback(
+    async (id) => {
+      try {
+        await api.post('/api/v1/culling/restore', { ids: [id] });
+        setTrashItems((prev) => prev.filter((it) => it.id !== id));
+        if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+      } catch (err) {
+        setError(err.message || String(err));
+      }
+    },
+    [api, loadList]
+  );
+
+  const emptyTrash = useCallback(async () => {
+    try {
+      await api.post('/api/v1/culling/empty', {});
+      setTrashItems([]);
+    } catch (err) {
+      setError(err.message || String(err));
+    }
+  }, [api]);
+
+  // ----- divider drag ------------------------------------------------
+  const startDrag = useCallback((e) => {
+    e.preventDefault();
+    const body = bodyRef.current;
+    if (!body) return;
+    const onMove = (ev) => {
+      const rect = body.getBoundingClientRect();
+      const pct = ((ev.clientX - rect.left) / rect.width) * 100;
+      setLeftWidthPct(Math.min(70, Math.max(15, pct)));
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, []);
+
+  const current = currentIndex >= 0 ? files[currentIndex] : null;
+  const canFilter = roots.length > 0 || glob.trim() !== '';
+
+  return (
+    <div className="module-container culling">
+      <div className="culling-filterbar">
+        <button className="btn-secondary" onClick={addFolders}>+ Mapp</button>
+        <select
+          className="form-select"
+          value={player}
+          onChange={(e) => selectPlayer(e.target.value)}
+          title="Spelare"
+        >
+          <option value="">Alla spelare</option>
+          {players.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+        <input
+          className="form-input culling-glob"
+          type="text"
+          placeholder="Glob, t.ex. *ArvidW*"
+          value={glob}
+          onChange={(e) => { setGlob(e.target.value); setPlayer(''); }}
+          onKeyDown={(e) => { if (e.key === 'Enter') runFilter(); }}
+        />
+        <button className="btn-primary" onClick={runFilter} disabled={!canFilter || isLoading}>
+          {isLoading ? '…' : 'Visa'}
+        </button>
+        <span className="culling-spacer" />
+        <button
+          className={showTrash ? 'btn-primary' : 'btn-secondary'}
+          onClick={() => (showTrash ? setShowTrash(false) : openTrash())}
+        >
+          Papperskorg
+        </button>
+      </div>
+
+      {roots.length > 0 && (
+        <div className="culling-roots">
+          {roots.map((r) => (
+            <span className="culling-chip" key={r} title={r}>
+              {basename(r)}
+              <button className="culling-chip-x" onClick={() => setRoots((rs) => rs.filter((x) => x !== r))}>×</button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {error && <div className="status-message error">Fel: {error}</div>}
+
+      {showTrash ? (
+        <div className="module-body culling-trashview">
+          <div className="culling-trash-header">
+            <span>{trashItems.length} i papperskorgen</span>
+            {trashItems.length > 0 && (
+              <button className="btn-secondary" onClick={emptyTrash}>Töm</button>
+            )}
+          </div>
+          {trashItems.length === 0 ? (
+            <div className="empty-state">Papperskorgen är tom.</div>
+          ) : (
+            <ul className="culling-trash-list">
+              {trashItems.map((it) => (
+                <li key={it.id}>
+                  <span className="culling-trash-name" title={it.original_path}>{it.basename}</span>
+                  <button className="btn-secondary" onClick={() => restoreItem(it.id)}>Återställ</button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : (
+        <div className="culling-body" ref={bodyRef}>
+          <div className="culling-list" style={{ width: `${leftWidthPct}%` }}>
+            <div className="culling-list-header">
+              {files.length} bilder{player ? ` · ${player}` : ''}
+            </div>
+            {!hasRun && !isLoading && (
+              <div className="empty-state">Välj mapp + spelare/glob och tryck <strong>Visa</strong>.</div>
+            )}
+            {hasRun && files.length === 0 && !isLoading && (
+              <div className="empty-state">Inga bilder.</div>
+            )}
+            <ul className="culling-files">
+              {files.map((f, i) => (
+                <li
+                  key={f.path}
+                  className={i === currentIndex ? 'active' : ''}
+                  onClick={() => setCurrentIndex(i)}
+                >
+                  <span className="culling-file-name">{f.basename}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="culling-divider" onMouseDown={startDrag} />
+
+          <div className="culling-preview">
+            {current ? (
+              <img className="culling-image" src={toFileUrl(current.path)} alt={current.basename} />
+            ) : (
+              <div className="empty-state">Ingen bild vald.</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// file:// URL builder - mirrors ImageViewer.loadImage encoding.
+function toFileUrl(p) {
+  if (p.startsWith('file://')) return p;
+  const normalized = p.replace(/\\/g, '/');
+  const isWin = /^[a-zA-Z]:\//.test(normalized);
+  const encoded = encodeURI(normalized)
+    .replace(/#/g, '%23')
+    .replace(/\?/g, '%3F')
+    .replace(/\[/g, '%5B')
+    .replace(/\]/g, '%5D');
+  return isWin ? 'file:///' + encoded : 'file://' + encoded;
+}
+
+function globBaseDir(pattern) {
+  const idx = pattern.search(/[*?[]/);
+  const literal = idx === -1 ? pattern : pattern.slice(0, idx);
+  const slash = literal.lastIndexOf('/');
+  return slash === -1 ? '' : literal.slice(0, slash);
+}
+
+function basename(p) {
+  const parts = p.replace(/\/+$/, '').split('/');
+  return parts[parts.length - 1] || p;
+}
+
+export default CullingModule;

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -142,7 +142,12 @@ export function CullingModule({ node }) {
   const addFolders = useCallback(async () => {
     try {
       const paths = await window.ansiktenAPI.invoke('open-folder-paths');
-      if (paths && paths.length) setRoots((r) => Array.from(new Set([...r, ...paths])));
+      if (paths && paths.length) {
+        setRoots((r) => Array.from(new Set([...r, ...paths])));
+        // A manual folder choice replaces the (hidden) scan source carried from a
+        // glob-only count, so the stale glob can't silently mix into the results.
+        setCarriedGlobs([]);
+      }
     } catch (err) {
       console.error('[Culling] folder pick failed', err);
     }
@@ -289,11 +294,17 @@ export function CullingModule({ node }) {
   const restoreItem = useCallback(
     async (id) => {
       try {
-        await api.post('/api/v1/culling/restore', { ids: [id] });
-        setTrashItems((prev) => prev.filter((it) => it.id !== id));
-        // Keep the cull-loop undo stack in sync - this id is no longer trashable.
-        undoStackRef.current = undoStackRef.current.filter((x) => x !== id);
-        if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+        const res = await api.post('/api/v1/culling/restore', { ids: [id] });
+        if (res.restored && res.restored.length > 0) {
+          setTrashItems((prev) => prev.filter((it) => it.id !== id));
+          // Keep the cull-loop undo stack in sync - this id is no longer trashable.
+          undoStackRef.current = undoStackRef.current.filter((x) => x !== id);
+          if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+        } else {
+          // 200 with errors[] (unwritable folder, missing stored file): the item
+          // stays in the manifest, so keep it visible and surface the reason.
+          setError(res.errors?.[0]?.error || 'Kunde inte återställa filen.');
+        }
       } catch (err) {
         setError(err.message || String(err));
       }

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -24,6 +24,13 @@ export function CullingModule({ node }) {
   const [glob, setGlob] = useState('');
   const [player, setPlayer] = useState('');
   const [players, setPlayers] = useState([]);
+  // Scope carried from the stats module (glob-only runs, date span, recursion).
+  // The culling bar has no date inputs, so we keep these to honour the count's
+  // selection and to preserve scope across a manual re-"Visa".
+  const [carriedGlobs, setCarriedGlobs] = useState([]);
+  const [dateFrom, setDateFrom] = useState(null);
+  const [dateTo, setDateTo] = useState(null);
+  const [recursive, setRecursive] = useState(true);
 
   const [files, setFiles] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(-1);
@@ -43,27 +50,31 @@ export function CullingModule({ node }) {
   const debounceRef = useRef(null);
   const bodyRef = useRef(null);
 
+  // The editable glob is a Finder-style basename filter (name_glob) over the
+  // resolved files, NOT an independent filesystem glob. The scan source is
+  // roots (+ any path-globs carried from the stats module).
   const buildQuery = useCallback(
     () => ({
       roots,
-      globs: glob.trim() ? [glob.trim()] : [],
+      globs: carriedGlobs,
       extension_preset: 'jpg',
-      recursive: true,
-      player: player || null,
+      recursive,
+      date_from: dateFrom,
+      date_to: dateTo,
+      name_glob: glob.trim() || null,
     }),
-    [roots, glob, player]
+    [roots, carriedGlobs, recursive, dateFrom, dateTo, glob]
   );
 
   // ----- folder watching (live refresh) ------------------------------
   const watchDirs = useCallback(() => {
     const dirs = new Set(roots);
-    const g = glob.trim();
-    if (g) {
+    for (const g of carriedGlobs) {
       const base = globBaseDir(g);
       if (base) dirs.add(base);
     }
     return dirs;
-  }, [roots, glob]);
+  }, [roots, carriedGlobs]);
 
   const updateWatches = useCallback((desired) => {
     const current = watchedDirsRef.current;
@@ -134,33 +145,52 @@ export function CullingModule({ node }) {
     }
   }, []);
 
+  // Picking a player fills the editable glob with a basename pattern (the user's
+  // "klicka till glob" affordance); the directory scope (roots) is untouched.
   const selectPlayer = useCallback((name) => {
     setPlayer(name);
     setGlob(name ? `*${name}*` : '');
   }, []);
 
-  // Open filtered to a player from the stats module.
+  // Open filtered to a player from the stats module, honouring the count's full
+  // scope: folders OR path-globs, the date span, and the recursion flag.
   useModuleEvent(
     'cull-player',
     (data) => {
       if (!data) return;
-      if (data.roots) setRoots(data.roots);
-      if (data.name) {
-        setPlayer(data.name);
-        setGlob(`*${data.name}*`);
-      }
+      const nextRoots = data.roots || [];
+      const nextGlobs = data.globs || [];
+      const nextRecursive = data.recursive ?? true;
+      const nextFrom = data.date_from || null;
+      const nextTo = data.date_to || null;
+      setRoots(nextRoots);
+      setCarriedGlobs(nextGlobs);
+      setRecursive(nextRecursive);
+      setDateFrom(nextFrom);
+      setDateTo(nextTo);
+      setPlayer(data.name || '');
+      setGlob(data.name ? `*${data.name}*` : '');
+
       const query = {
-        roots: data.roots || roots,
-        globs: [],
+        roots: nextRoots,
+        globs: nextGlobs,
         extension_preset: 'jpg',
-        recursive: true,
-        player: data.name || null,
+        recursive: nextRecursive,
+        date_from: nextFrom,
+        date_to: nextTo,
+        name_glob: data.name ? `*${data.name}*` : null,
       };
       lastQueryRef.current = query;
       loadList(query);
-      updateWatches(new Set(data.roots || roots));
+
+      const dirs = new Set(nextRoots);
+      for (const g of nextGlobs) {
+        const base = globBaseDir(g);
+        if (base) dirs.add(base);
+      }
+      updateWatches(dirs);
     },
-    [roots, loadList, updateWatches]
+    [loadList, updateWatches]
   );
 
   // ----- cull loop ----------------------------------------------------
@@ -186,13 +216,21 @@ export function CullingModule({ node }) {
   }, [api, currentIndex, files, loadList]);
 
   const undoTrash = useCallback(async () => {
-    const id = undoStackRef.current.pop();
-    if (!id) return;
-    try {
-      await api.post('/api/v1/culling/restore', { ids: [id] });
-      if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
-    } catch (err) {
-      setError(err.message || String(err));
+    // Pop until a still-trashed id restores - ids restored via the trash view
+    // are removed from the stack, but guard anyway so Cmd+Z never no-ops loudly.
+    while (undoStackRef.current.length > 0) {
+      const id = undoStackRef.current.pop();
+      try {
+        const res = await api.post('/api/v1/culling/restore', { ids: [id] });
+        if (res.restored && res.restored.length > 0) {
+          if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+          return;
+        }
+        // id no longer in trash -> fall through and try the next one.
+      } catch (err) {
+        setError(err.message || String(err));
+        return;
+      }
     }
   }, [api, loadList]);
 
@@ -242,6 +280,8 @@ export function CullingModule({ node }) {
       try {
         await api.post('/api/v1/culling/restore', { ids: [id] });
         setTrashItems((prev) => prev.filter((it) => it.id !== id));
+        // Keep the cull-loop undo stack in sync - this id is no longer trashable.
+        undoStackRef.current = undoStackRef.current.filter((x) => x !== id);
         if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
       } catch (err) {
         setError(err.message || String(err));
@@ -254,6 +294,7 @@ export function CullingModule({ node }) {
     try {
       await api.post('/api/v1/culling/empty', {});
       setTrashItems([]);
+      undoStackRef.current = [];
     } catch (err) {
       setError(err.message || String(err));
     }

--- a/frontend/src/renderer/components/InputBar.css
+++ b/frontend/src/renderer/components/InputBar.css
@@ -1,0 +1,73 @@
+.input-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.input-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.input-bar-row-secondary {
+  font-size: 0.85em;
+  color: var(--text-secondary);
+}
+
+.input-bar-glob {
+  flex: 1 1 240px;
+  min-width: 160px;
+}
+
+.input-bar-date {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.input-bar-date input[type="date"] {
+  width: auto;
+}
+
+.input-bar-roots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.input-bar-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  border-radius: 12px;
+  background: var(--bg-tertiary, var(--bg-primary));
+  border: 1px solid var(--border-color);
+  font-size: 0.8em;
+  max-width: 220px;
+}
+
+.input-bar-chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.input-bar-chip-remove {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.input-bar-chip-remove:hover {
+  color: var(--text-primary);
+}

--- a/frontend/src/renderer/components/InputBar.jsx
+++ b/frontend/src/renderer/components/InputBar.jsx
@@ -1,0 +1,168 @@
+/**
+ * InputBar - Reusable folder/glob + extension preset + date span selector.
+ *
+ * Tier-0 shared component for CLI-onboarding modules: the user picks one or more
+ * folders and/or a wildcard pattern, an extension preset (jpg|jpeg / nef / ...),
+ * and an optional date span. Controlled component: parent owns `value` and
+ * receives changes via `onChange`; `onSubmit` fires on the "Räkna" button / Enter.
+ *
+ * The backend does the actual globbing — this only collects parameters.
+ */
+
+import React, { useCallback } from 'react';
+import './InputBar.css';
+
+export const DEFAULT_PRESETS = [
+  { value: 'jpg', label: 'jpg / jpeg' },
+  { value: 'nef', label: 'nef' },
+  { value: 'raw', label: 'raw (alla)' },
+  { value: 'images', label: 'bilder (jpg/png/tiff)' },
+  { value: 'all', label: 'alla format' },
+];
+
+export const EMPTY_INPUT = {
+  roots: [],
+  glob: '',
+  preset: 'jpg',
+  dateFrom: '',
+  dateTo: '',
+  recursive: true,
+};
+
+export function InputBar({
+  value,
+  onChange,
+  onSubmit,
+  presets = DEFAULT_PRESETS,
+  busy = false,
+  submitLabel = 'Räkna',
+}) {
+  const patch = useCallback(
+    (partial) => onChange({ ...value, ...partial }),
+    [value, onChange]
+  );
+
+  const addFolders = useCallback(async () => {
+    try {
+      const paths = await window.ansiktenAPI.invoke('open-folder-paths');
+      if (!paths || paths.length === 0) return;
+      const merged = Array.from(new Set([...value.roots, ...paths]));
+      onChange({ ...value, roots: merged });
+    } catch (err) {
+      console.error('[InputBar] Failed to pick folder:', err);
+    }
+  }, [value, onChange]);
+
+  const removeRoot = useCallback(
+    (root) => patch({ roots: value.roots.filter((r) => r !== root) }),
+    [value.roots, patch]
+  );
+
+  const canSubmit = !busy && (value.roots.length > 0 || value.glob.trim() !== '');
+
+  const submit = useCallback(() => {
+    if (canSubmit) onSubmit();
+  }, [canSubmit, onSubmit]);
+
+  const onGlobKeyDown = useCallback(
+    (e) => {
+      if (e.key === 'Enter') submit();
+    },
+    [submit]
+  );
+
+  return (
+    <div className="input-bar">
+      <div className="input-bar-row">
+        <button className="btn-secondary" onClick={addFolders} disabled={busy}>
+          + Mapp
+        </button>
+
+        <input
+          className="form-input input-bar-glob"
+          type="text"
+          placeholder="Wildcard, t.ex. ~/Pictures/250601*.jpg"
+          value={value.glob}
+          onChange={(e) => patch({ glob: e.target.value })}
+          onKeyDown={onGlobKeyDown}
+          disabled={busy}
+        />
+
+        <select
+          className="form-select"
+          value={value.preset}
+          onChange={(e) => patch({ preset: e.target.value })}
+          disabled={busy}
+          title="Filtyper (skiftlägesokänsligt)"
+        >
+          {presets.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+
+        <button className="btn-primary" onClick={submit} disabled={!canSubmit}>
+          {busy ? '…' : submitLabel}
+        </button>
+      </div>
+
+      <div className="input-bar-row input-bar-row-secondary">
+        <label className="input-bar-date">
+          Från
+          <input
+            className="form-input"
+            type="date"
+            value={value.dateFrom}
+            onChange={(e) => patch({ dateFrom: e.target.value })}
+            disabled={busy}
+          />
+        </label>
+        <label className="input-bar-date">
+          Till
+          <input
+            className="form-input"
+            type="date"
+            value={value.dateTo}
+            onChange={(e) => patch({ dateTo: e.target.value })}
+            disabled={busy}
+          />
+        </label>
+        <label className="form-checkbox">
+          <input
+            type="checkbox"
+            checked={value.recursive}
+            onChange={(e) => patch({ recursive: e.target.checked })}
+            disabled={busy}
+          />
+          Inkl. undermappar
+        </label>
+      </div>
+
+      {value.roots.length > 0 && (
+        <div className="input-bar-roots">
+          {value.roots.map((root) => (
+            <span className="input-bar-chip" key={root} title={root}>
+              <span className="input-bar-chip-label">{basename(root)}</span>
+              <button
+                className="input-bar-chip-remove"
+                onClick={() => removeRoot(root)}
+                disabled={busy}
+                aria-label={`Ta bort ${root}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function basename(p) {
+  const parts = p.replace(/\/+$/, '').split('/');
+  return parts[parts.length - 1] || p;
+}
+
+export default InputBar;

--- a/frontend/src/renderer/components/PlayerCountModule.css
+++ b/frontend/src/renderer/components/PlayerCountModule.css
@@ -1,0 +1,112 @@
+.player-count {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.player-count-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.player-count-refreshing {
+  font-size: 0.8em;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.player-count-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.9em;
+}
+
+.player-count-dim {
+  color: var(--text-secondary);
+}
+
+.player-count-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9em;
+}
+
+.player-count-table th,
+.player-count-table td {
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.player-count-table th {
+  color: var(--text-secondary);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.player-count-table td.num,
+.player-count-table th.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.player-count-table tbody tr:hover {
+  background: var(--bg-secondary);
+}
+
+.player-count-table tbody tr.clickable {
+  cursor: pointer;
+}
+
+.player-count-table .bar-col {
+  width: 35%;
+}
+
+.player-bar-track {
+  width: 100%;
+  height: 10px;
+  background: var(--bg-tertiary, var(--bg-secondary));
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.player-bar-fill {
+  height: 100%;
+  border-radius: 5px;
+}
+
+/* Deviation levels mirror the CLI color thresholds (ok/warn/high). */
+.player-bar-fill.level-ok { background: var(--success, #3ba55d); }
+.player-bar-fill.level-warn { background: var(--warning, #d9a441); }
+.player-bar-fill.level-high { background: var(--error, #d65b5b); }
+
+.delta.delta-ok { color: var(--success, #3ba55d); }
+.delta.delta-warn { color: var(--warning, #d9a441); }
+.delta.delta-high { color: var(--error, #d65b5b); }
+
+.player-count-excluded,
+.player-count-matches {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.player-count-group > summary {
+  cursor: pointer;
+  padding: 4px 0;
+  color: var(--text-secondary);
+  font-size: 0.9em;
+  user-select: none;
+}
+
+.player-count-group ul {
+  margin: 4px 0 8px 16px;
+  padding: 0;
+  font-size: 0.85em;
+  color: var(--text-secondary);
+}

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -1,0 +1,321 @@
+/**
+ * PlayerCountModule - GUI for the rakna_spelare CLI.
+ *
+ * Counts how many images each named player appears in across a folder/glob/date
+ * selection, with over/under-representation statistics. The input bar collects a
+ * folder/wildcard + extension preset + date span; the backend resolves the files
+ * and counts. Stats auto-refresh live when the watched folder(s) change.
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useBackend } from '../context/BackendContext.jsx';
+import { useModuleAPI } from '../hooks/useModuleEvent.js';
+import { InputBar, EMPTY_INPUT } from './InputBar.jsx';
+import './PlayerCountModule.css';
+
+const REFRESH_DEBOUNCE_MS = 400;
+
+export function PlayerCountModule() {
+  const { api } = useBackend();
+  const { emit, waitForListeners } = useModuleAPI();
+
+  const [input, setInput] = useState(EMPTY_INPUT);
+  const [perMatch, setPerMatch] = useState(false);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasRun, setHasRun] = useState(false);
+
+  // Params of the last submitted query, so auto-refresh re-runs the same thing.
+  const lastParamsRef = useRef(null);
+  const watchedDirsRef = useRef(new Set());
+  const debounceRef = useRef(null);
+
+  const buildParams = useCallback(
+    (inp, includePerMatch) => ({
+      roots: inp.roots,
+      globs: inp.glob.trim() ? [inp.glob.trim()] : [],
+      extension_preset: inp.preset,
+      recursive: inp.recursive,
+      date_from: inp.dateFrom || null,
+      date_to: inp.dateTo || null,
+      per_match: includePerMatch,
+    }),
+    []
+  );
+
+  const runCount = useCallback(
+    async (params, { silent = false } = {}) => {
+      if (silent) setIsRefreshing(true);
+      else setIsLoading(true);
+      try {
+        const data = await api.post('/api/v1/players/count', params);
+        setResult(data);
+        setError(null);
+      } catch (err) {
+        setError(err.message || String(err));
+      } finally {
+        setIsLoading(false);
+        setIsRefreshing(false);
+        setHasRun(true);
+      }
+    },
+    [api]
+  );
+
+  // Compute the directories to watch for a given input.
+  const watchDirsFor = useCallback((inp) => {
+    const dirs = new Set(inp.roots);
+    const g = inp.glob.trim();
+    if (g) {
+      const base = globBaseDir(g);
+      if (base) dirs.add(base);
+    }
+    return dirs;
+  }, []);
+
+  // Reconcile the active folder watches with the desired set.
+  const updateWatches = useCallback((desired) => {
+    const current = watchedDirsRef.current;
+    for (const dir of current) {
+      if (!desired.has(dir)) {
+        window.ansiktenAPI.unwatchFolder?.(dir);
+      }
+    }
+    for (const dir of desired) {
+      if (!current.has(dir)) {
+        window.ansiktenAPI.watchFolder?.(dir, true);
+      }
+    }
+    watchedDirsRef.current = desired;
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    const params = buildParams(input, perMatch);
+    lastParamsRef.current = params;
+    runCount(params);
+    updateWatches(watchDirsFor(input));
+  }, [input, perMatch, buildParams, runCount, updateWatches, watchDirsFor]);
+
+  // Open the culling workspace filtered to a player (from the stats table).
+  const openCullForPlayer = useCallback(
+    async (name) => {
+      const params = lastParamsRef.current || buildParams(input, perMatch);
+      window.workspace?.openModule?.('culling');
+      // The culling module subscribes on mount; wait so the event isn't missed.
+      await waitForListeners('cull-player', 3000);
+      emit('cull-player', {
+        name,
+        roots: params.roots,
+        recursive: params.recursive,
+        date_from: params.date_from,
+        date_to: params.date_to,
+      });
+    },
+    [emit, waitForListeners, input, perMatch, buildParams]
+  );
+
+  // Subscribe to folder-change events for live auto-refresh.
+  useEffect(() => {
+    const unsubscribe = window.ansiktenAPI.onFolderChanged?.(() => {
+      if (!lastParamsRef.current) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        runCount(lastParamsRef.current, { silent: true });
+      }, REFRESH_DEBOUNCE_MS);
+    });
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (unsubscribe) unsubscribe();
+      for (const dir of watchedDirsRef.current) {
+        window.ansiktenAPI.unwatchFolder?.(dir);
+      }
+      watchedDirsRef.current = new Set();
+    };
+  }, [runCount]);
+
+  const totalImages = result?.total_images ?? 0;
+
+  return (
+    <div className="module-container player-count">
+      <div className="module-header">
+        <h3 className="module-title">Räkna spelare</h3>
+        <div className="button-group">
+          <label className="form-checkbox">
+            <input
+              type="checkbox"
+              checked={perMatch}
+              onChange={(e) => setPerMatch(e.target.checked)}
+            />
+            Per match
+          </label>
+          {isRefreshing && <span className="player-count-refreshing">uppdaterar…</span>}
+        </div>
+      </div>
+
+      <InputBar value={input} onChange={setInput} onSubmit={handleSubmit} busy={isLoading} />
+
+      <div className="module-body player-count-body">
+        {error && <div className="status-message error">Fel: {error}</div>}
+
+        {isLoading && <div className="empty-state">Räknar…</div>}
+
+        {!isLoading && !error && !hasRun && (
+          <div className="empty-state">
+            Välj en mapp eller ange ett wildcard och tryck <strong>Räkna</strong>.
+          </div>
+        )}
+
+        {!isLoading && !error && hasRun && result && (
+          <>
+            <ResultSummary result={result} />
+            {totalImages === 0 ? (
+              <div className="empty-state">Inga matchande bilder hittades.</div>
+            ) : (
+              <>
+                <PlayerTable players={result.players} totalImages={totalImages} onPlayerClick={openCullForPlayer} />
+                <ExcludedSections excluded={result.excluded} />
+                {perMatch && result.matches?.length > 0 && (
+                  <MatchSections matches={result.matches} onPlayerClick={openCullForPlayer} />
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ResultSummary({ result }) {
+  const tr = result.time_range;
+  return (
+    <div className="player-count-summary">
+      <span><strong>{result.total_images}</strong> bilder</span>
+      <span><strong>{result.players.length}</strong> spelare</span>
+      <span>Baseline ({result.baseline_method}): <strong>{result.baseline}</strong></span>
+      {result.files_resolved != null && (
+        <span className="player-count-dim">{result.files_resolved} filer</span>
+      )}
+      {tr && (
+        <span className="player-count-dim">
+          {fmtTime(tr.start)} → {fmtTime(tr.end)} ({Math.round(tr.duration_minutes)} min)
+        </span>
+      )}
+    </div>
+  );
+}
+
+function PlayerTable({ players, totalImages, onPlayerClick }) {
+  const maxCount = players.reduce((m, p) => Math.max(m, p.count), 1);
+  return (
+    <table className="player-count-table">
+      <thead>
+        <tr>
+          <th>Namn</th>
+          <th className="num">Antal</th>
+          <th className="num">%</th>
+          <th className="num">Δ%</th>
+          <th className="bar-col">Fördelning</th>
+        </tr>
+      </thead>
+      <tbody>
+        {players.map((p) => (
+          <tr
+            key={p.name}
+            className={onPlayerClick ? 'clickable' : ''}
+            onClick={onPlayerClick ? () => onPlayerClick(p.name) : undefined}
+            title={onPlayerClick ? `Gallra ${p.name}` : undefined}
+          >
+            <td>{p.name}</td>
+            <td className="num">{p.count}</td>
+            <td className="num">{p.pct}%</td>
+            <td className={`num delta delta-${p.level}`}>
+              {p.delta_pct > 0 ? '+' : ''}{p.delta_pct}%
+            </td>
+            <td className="bar-col">
+              <div className="player-bar-track">
+                <div
+                  className={`player-bar-fill level-${p.level}`}
+                  style={{ width: `${(p.count / maxCount) * 100}%` }}
+                />
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+const EXCLUDED_LABELS = {
+  tranare: 'Tränare',
+  grupp: 'Gruppbilder',
+  publik: 'Publik',
+  below_threshold: 'Under tröskeln',
+};
+
+function ExcludedSections({ excluded }) {
+  if (!excluded) return null;
+  const groups = Object.entries(EXCLUDED_LABELS).filter(
+    ([key]) => excluded[key] && excluded[key].length > 0
+  );
+  if (groups.length === 0) return null;
+
+  return (
+    <div className="player-count-excluded">
+      {groups.map(([key, label]) => (
+        <details key={key} className="player-count-group">
+          <summary>{label} ({excluded[key].length})</summary>
+          <ul>
+            {excluded[key].map((e) => (
+              <li key={e.name}>{e.name}: {e.count} ({e.pct}%)</li>
+            ))}
+          </ul>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function MatchSections({ matches, onPlayerClick }) {
+  return (
+    <div className="player-count-matches">
+      {matches.map((m) => (
+        <details key={m.index} className="player-count-group">
+          <summary>
+            Match {m.index} — {fmtDateTime(m.start)} → {fmtTime(m.end)} ({Math.round(m.duration_minutes)} min, {m.total_images} bilder)
+          </summary>
+          {m.players.length > 0 ? (
+            <PlayerTable players={m.players} totalImages={m.total_images} onPlayerClick={onPlayerClick} />
+          ) : (
+            <div className="empty-state compact">Inga spelare över tröskeln.</div>
+          )}
+        </details>
+      ))}
+    </div>
+  );
+}
+
+// Directory before the first wildcard char in a glob pattern.
+function globBaseDir(pattern) {
+  const wildcardIdx = pattern.search(/[*?[]/);
+  const literal = wildcardIdx === -1 ? pattern : pattern.slice(0, wildcardIdx);
+  const slashIdx = literal.lastIndexOf('/');
+  if (slashIdx === -1) return '';
+  return literal.slice(0, slashIdx);
+}
+
+function fmtTime(iso) {
+  if (!iso) return '';
+  return iso.slice(11, 16);
+}
+
+function fmtDateTime(iso) {
+  if (!iso) return '';
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)}`;
+}
+
+export default PlayerCountModule;

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -108,6 +108,7 @@ export function PlayerCountModule() {
       emit('cull-player', {
         name,
         roots: params.roots,
+        globs: params.globs,
         recursive: params.recursive,
         date_from: params.date_from,
         date_to: params.date_to,

--- a/frontend/src/renderer/components/index.js
+++ b/frontend/src/renderer/components/index.js
@@ -6,6 +6,8 @@ export { ImageViewer } from './ImageViewer.jsx';
 export { OriginalView } from './OriginalView.jsx';
 export { LogViewer } from './LogViewer.jsx';
 export { StatisticsDashboard } from './StatisticsDashboard.jsx';
+export { PlayerCountModule } from './PlayerCountModule.jsx';
+export { CullingModule } from './CullingModule.jsx';
 export { ReviewModule } from './ReviewModule.jsx';
 export { DatabaseManagement } from './DatabaseManagement.jsx';
 export { StartupStatus } from './StartupStatus.jsx';

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -24,6 +24,8 @@ import { FileQueueModule } from '../../components/FileQueueModule.jsx';
 import { ThemeEditor } from '../../components/ThemeEditor.jsx';
 import { PreferencesModule } from '../../components/PreferencesModule.jsx';
 import { RefineFacesModule } from '../../components/RefineFacesModule.jsx';
+import { PlayerCountModule } from '../../components/PlayerCountModule.jsx';
+import { CullingModule } from '../../components/CullingModule.jsx';
 
 
 // Storage key for layout persistence
@@ -174,7 +176,9 @@ const MODULE_COMPONENTS = {
   'refine-faces': RefineFacesModule,
   'file-queue': FileQueueModule,
   'theme-editor': ThemeEditor,
-  'preferences': PreferencesModule
+  'preferences': PreferencesModule,
+  'player-count': PlayerCountModule,
+  'culling': CullingModule
 };
 
 // Module titles
@@ -188,7 +192,9 @@ const MODULE_TITLES = {
   'refine-faces': 'Refine Faces',
   'file-queue': 'File Queue',
   'theme-editor': 'Theme Editor',
-  'preferences': 'Preferences'
+  'preferences': 'Preferences',
+  'player-count': 'Räkna spelare',
+  'culling': 'Gallra spelare'
 };
 
 // Module-specific default layout ratios
@@ -233,6 +239,16 @@ const MODULE_LAYOUT = {
   },
   'theme-editor': {
     widthRatio: 0.50,     // 50% when sharing row
+    heightRatio: 0.70,    // Primary row
+    row: 1
+  },
+  'player-count': {
+    widthRatio: 0.50,     // 50% when sharing row
+    heightRatio: 0.70,    // Primary row
+    row: 1
+  },
+  'culling': {
+    widthRatio: 0.70,     // wide - it holds list + image side by side
     heightRatio: 0.70,    // Primary row
     row: 1
   }
@@ -454,7 +470,9 @@ export function FlexLayoutWorkspace() {
     'log-viewer',
     'database-management',
     'refine-faces',
-    'theme-editor'
+    'theme-editor',
+    'player-count',
+    'culling'
   ]);
 
   // Open a module tab
@@ -1114,6 +1132,12 @@ export function FlexLayoutWorkspace() {
           break;
         case 'open-statistics-dashboard':
           openModule('statistics-dashboard');
+          break;
+        case 'open-player-count':
+          openModule('player-count');
+          break;
+        case 'open-culling':
+          openModule('culling');
           break;
         case 'open-database-management':
           openModule('database-management');


### PR DESCRIPTION
## Summary

First steps of bringing the CLI-only scripts into the GUI (roadmap in the dev plan). Two new modules plus shared infrastructure:

### Räkna spelare (player count)
GUI for the `rakna_spelare.py` logic — counts images per named player from filenames (no face recognition), with median-baseline over/under-representation stats.
- Shared backend `file_resolver` (folder/glob + case-insensitive extension preset + filename-date span).
- `rakna_spelare.py` refactored to expose a reusable counting core; CLI and API share one implementation (no logic fork).
- Top input bar, results table with colour-coded deviation, optional per-match breakdown.
- Live auto-refresh: the stats update when files in the watched folder(s) are added/removed/renamed.

### Gallra spelare (culling workspace)
Stats-driven culling on the developed JPEGs: pick a player, preview their photos, trash the weak ones recoverably until the players are balanced.
- Full-width filter bar (folder · player · editable glob) + resizable two-column body (file list / maximized image).
- Keyboard cull loop (`x`/Delete trashes + auto-advances; `Cmd+Z` restores).
- App-managed trash with restore-to-original (manifest-backed, never overwrites; collisions land as `-restored`). Trash lives outside the working folders, so trashed files drop out of the live counts automatically.
- Clicking a player row in Räkna spelare opens Gallra spelare filtered to them.

### Shared infrastructure
- Folder-level file-watching IPC (debounced) and a folder-path dialog, reused by both modules.
- Backend endpoints: `POST /api/v1/players/count`; `POST /api/v1/culling/files`, `/culling/trash` (POST/GET), `/culling/restore`, `/culling/empty`.

## Testing
- Backend verified end-to-end over HTTP: CLI↔API count parity on an identical fileset, case-insensitive presets, date-span filtering, and a full trash→restore→collision→empty round-trip with stats exclusion.
- Frontend builds clean; IPC channel and event names cross-checked.
- No automated test suite in this repo — interactive GUI pass is manual (`npx electron .`).
