### PR TITLE
Gallra spelare: NEF/RAW general culling

### DIFF
--- a/backend/api/services/culling_service.py
+++ b/backend/api/services/culling_service.py
@@ -22,10 +22,10 @@ from pathlib import Path
 # other services).
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from rakna_spelare import build_entries  # noqa: E402
+from rakna_spelare import parse_filename  # noqa: E402
 
 from .file_resolver import TRASH_DIR, preset_extensions, resolve_files  # noqa: E402
-from .rename_service import find_sidecar_files  # noqa: E402
+from .rename_service import extract_filename_datetime, find_sidecar_files  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,21 @@ class CullingService:
             date_from=date_from,
             date_to=date_to,
         )
-        entries = build_entries(files)
+
+        # Lenient listing: unlike the CLI counting core (build_entries), keep
+        # files that have no _Name part (e.g. YYMMDD_HHMMSS.NEF from general
+        # culling, which happens before names are assigned). Datetime comes from
+        # parse_filename when names exist, else the name-agnostic prefix parser.
+        entries: list[tuple] = []
+        for path in files:
+            dt, names = parse_filename(path)
+            if dt is None:
+                dt = extract_filename_datetime(Path(path).name)
+                names = []
+            if dt is None:
+                continue
+            entries.append((dt, names or [], path))
+        entries.sort(key=lambda e: e[0])
 
         glob_lower = name_glob.lower() if name_glob else None
 

--- a/backend/api/services/detection_service.py
+++ b/backend/api/services/detection_service.py
@@ -171,7 +171,10 @@ class DetectionService:
         """
         ext = image_path.suffix.lower()
 
-        if ext in ['.nef', '.cr2', '.arw']:  # RAW formats
+        # RAW formats handled by rawpy/libraw. Keep this aligned with the "raw"
+        # extension preset (file_resolver.EXTENSION_PRESETS["raw"]) so every RAW
+        # the GUI lets you pick can actually be converted/previewed.
+        if ext in ['.nef', '.cr2', '.cr3', '.arw', '.dng', '.raw', '.raf', '.orf', '.rw2']:  # RAW formats
             # Check preprocessing cache for converted JPG
             try:
                 cache = get_preprocessing_cache()

--- a/backend/api/services/file_resolver.py
+++ b/backend/api/services/file_resolver.py
@@ -20,7 +20,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from rakna_spelare import parse_filename  # noqa: E402
 
-from .rename_service import SUPPORTED_EXTENSIONS  # noqa: E402
+from .rename_service import SUPPORTED_EXTENSIONS, extract_filename_datetime  # noqa: E402
 
 # App-managed trash (soft-deleted files live here). Resolution always skips it so
 # trashed files are never re-counted or re-listed by any feature. The culling
@@ -123,7 +123,12 @@ def resolve_files(
         if not _matches_extension(path, allowed_lower):
             continue
         if date_filtering:
+            # parse_filename needs a _Name part; fall back to the name-agnostic
+            # prefix parser so un-named files (e.g. YYMMDD_HHMMSS.NEF from general
+            # culling) survive date filtering instead of being silently dropped.
             dt, _ = parse_filename(path)
+            if dt is None:
+                dt = extract_filename_datetime(os.path.basename(path))
             if dt is None:
                 continue
             d = dt.date()

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -689,8 +689,12 @@ backed). Trashed files are automatically excluded from listing and counting.
 
 List image files for the current filter. `player` is an exact parsed-name
 filter; `name_glob` is a case-insensitive Finder-style basename pattern
-(e.g. `*ArvidW*`) applied to the resolved files. Other fields match
-`/players/count`.
+(e.g. `*ArvidW*`) applied to the resolved files. `extension_preset` selects the
+file types (`jpg`/`nef`/`raw`/...). Other fields match `/players/count`.
+
+Unlike `/players/count`, this lists files **without** a `_Name` part too (e.g.
+`YYMMDD_HHMMSS.NEF` from general culling before names are assigned); their date
+is read from the `YYMMDD_HHMMSS` prefix and they contribute no `players` entries.
 
 **Response:**
 ```json

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -143,7 +143,10 @@ antal.
    läggs till, tas bort eller byter namn i mappen.
 2. Klicka på en spelare i tabellen för att öppna **Gallra spelare**
    (`Cmd+Shift+G`) filtrerad på den spelaren. Filtret kan finjusteras med
-   spelar-menyn eller ett eget glob (t.ex. `*ArvidW*`) i balken.
+   spelar-menyn eller ett eget glob (t.ex. `*ArvidW*`) i balken. Välj filtyp
+   (`jpg`/`nef`/`raw`) i balken — `nef`/`raw` används för allmän gallring på
+   råfiler innan namn satts (förhandsvisas via NEF→JPG-konvertering;
+   spelar-menyn är då tom och du filtrerar på mapp/datum/glob).
 3. Bläddra i fillistan till vänster (`↑`/`↓`); bilden visas maximerad till höger.
    Tryck `x` (eller `Delete`) för att flytta bilden till papperskorgen och gå
    vidare. `Cmd+Z` ångrar.

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -16,6 +16,9 @@ import { useModuleEvent } from '../hooks/useModuleEvent.js';
 import './CullingModule.css';
 
 const REFRESH_DEBOUNCE_MS = 400;
+// Delay RAW conversion until the selection settles, so fast keyboard stepping
+// only converts the file the user rests on, not every file passed through.
+const PREVIEW_DEBOUNCE_MS = 150;
 
 export function CullingModule({ node }) {
   const { api } = useBackend();
@@ -367,26 +370,33 @@ export function CullingModule({ node }) {
     }
     let cancelled = false;
     setPreviewLoading(true); setPreviewError(null); setPreviewUrl(null);
-    api.post('/api/v1/preprocessing/nef', { file_path: currentPath })
-      .then((res) => {
-        if (cancelled) return;
-        if (res.status === 'error' || !res.nef_jpg_path) {
-          setPreviewError(res.error || 'Kunde inte konvertera NEF.');
-        } else {
-          setPreviewUrl(toFileUrl(res.nef_jpg_path));
-        }
-      })
-      .catch((err) => { if (!cancelled) setPreviewError(err.message || String(err)); })
-      .finally(() => { if (!cancelled) setPreviewLoading(false); });
-    return () => { cancelled = true; };
+    // Debounced: clearing the timer on a fast step cancels the POST before it
+    // fires, so no abandoned conversions pile up behind the one the user lands on.
+    const timer = setTimeout(() => {
+      api.post('/api/v1/preprocessing/nef', { file_path: currentPath })
+        .then((res) => {
+          if (cancelled) return;
+          if (res.status === 'error' || !res.nef_jpg_path) {
+            setPreviewError(res.error || 'Kunde inte konvertera NEF.');
+          } else {
+            setPreviewUrl(toFileUrl(res.nef_jpg_path));
+          }
+        })
+        .catch((err) => { if (!cancelled) setPreviewError(err.message || String(err)); })
+        .finally(() => { if (!cancelled) setPreviewLoading(false); });
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [currentPath, api]);
 
-  // Prefetch the next RAW so stepping through is usually a cache hit.
+  // Prefetch the next RAW so stepping through is usually a cache hit - also
+  // debounced, so a fast run of keypresses only warms the file after the rest.
   useEffect(() => {
     const next = files[currentIndex + 1];
-    if (next && isRaw(next.path)) {
+    if (!next || !isRaw(next.path)) return;
+    const timer = setTimeout(() => {
       api.post('/api/v1/preprocessing/nef', { file_path: next.path }).catch(() => {});
-    }
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
   }, [currentIndex, files, api]);
 
   return (

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -24,6 +24,7 @@ export function CullingModule({ node }) {
   const [glob, setGlob] = useState('');
   const [player, setPlayer] = useState('');
   const [players, setPlayers] = useState([]);
+  const [preset, setPreset] = useState('jpg'); // jpg | nef | raw
   // Scope carried from the stats module (glob-only runs, date span, recursion).
   // The culling bar has no date inputs, so we keep these to honour the count's
   // selection and to preserve scope across a manual re-"Visa".
@@ -43,6 +44,12 @@ export function CullingModule({ node }) {
 
   const [leftWidthPct, setLeftWidthPct] = useState(32);
 
+  // Resolved preview for the right pane. JPEGs load directly; RAW goes through
+  // the NEF->JPG pipeline, so resolution is async.
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState(null);
+
   // Latest filter params for auto-refresh; undo stack of trashed ids.
   const lastQueryRef = useRef(null);
   const undoStackRef = useRef([]);
@@ -57,7 +64,7 @@ export function CullingModule({ node }) {
     () => ({
       roots,
       globs: carriedGlobs,
-      extension_preset: 'jpg',
+      extension_preset: preset,
       recursive,
       date_from: dateFrom,
       date_to: dateTo,
@@ -66,7 +73,7 @@ export function CullingModule({ node }) {
       player: player || null,
       name_glob: glob.trim() || null,
     }),
-    [roots, carriedGlobs, recursive, dateFrom, dateTo, player, glob]
+    [roots, carriedGlobs, preset, recursive, dateFrom, dateTo, player, glob]
   );
 
   // ----- folder watching (live refresh) ------------------------------
@@ -178,6 +185,8 @@ export function CullingModule({ node }) {
       setDateTo(nextTo);
       setPlayer(data.name || '');
       setGlob(data.name ? `*${data.name}*` : '');
+      // Stats culling is always on developed JPEGs.
+      setPreset('jpg');
 
       const query = {
         roots: nextRoots,
@@ -343,10 +352,57 @@ export function CullingModule({ node }) {
   const current = currentIndex >= 0 ? files[currentIndex] : null;
   const canFilter = roots.length > 0 || glob.trim() !== '';
 
+  // Resolve the preview for the current file. RAW is converted via the NEF
+  // pipeline; the cancelled guard prevents a slow conversion from painting over
+  // a newer selection when the user steps quickly.
+  const currentPath = current?.path;
+  useEffect(() => {
+    if (!currentPath) {
+      setPreviewUrl(null); setPreviewError(null); setPreviewLoading(false);
+      return;
+    }
+    if (!isRaw(currentPath)) {
+      setPreviewUrl(toFileUrl(currentPath)); setPreviewError(null); setPreviewLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setPreviewLoading(true); setPreviewError(null); setPreviewUrl(null);
+    api.post('/api/v1/preprocessing/nef', { file_path: currentPath })
+      .then((res) => {
+        if (cancelled) return;
+        if (res.status === 'error' || !res.nef_jpg_path) {
+          setPreviewError(res.error || 'Kunde inte konvertera NEF.');
+        } else {
+          setPreviewUrl(toFileUrl(res.nef_jpg_path));
+        }
+      })
+      .catch((err) => { if (!cancelled) setPreviewError(err.message || String(err)); })
+      .finally(() => { if (!cancelled) setPreviewLoading(false); });
+    return () => { cancelled = true; };
+  }, [currentPath, api]);
+
+  // Prefetch the next RAW so stepping through is usually a cache hit.
+  useEffect(() => {
+    const next = files[currentIndex + 1];
+    if (next && isRaw(next.path)) {
+      api.post('/api/v1/preprocessing/nef', { file_path: next.path }).catch(() => {});
+    }
+  }, [currentIndex, files, api]);
+
   return (
     <div className="module-container culling">
       <div className="culling-filterbar">
         <button className="btn-secondary" onClick={addFolders}>+ Mapp</button>
+        <select
+          className="form-select"
+          value={preset}
+          onChange={(e) => setPreset(e.target.value)}
+          title="Filtyp"
+        >
+          <option value="jpg">jpg / jpeg</option>
+          <option value="nef">nef</option>
+          <option value="raw">raw (alla)</option>
+        </select>
         <select
           className="form-select"
           value={player}
@@ -440,16 +496,29 @@ export function CullingModule({ node }) {
           <div className="culling-divider" onMouseDown={startDrag} />
 
           <div className="culling-preview">
-            {current ? (
-              <img className="culling-image" src={toFileUrl(current.path)} alt={current.basename} />
-            ) : (
+            {!current ? (
               <div className="empty-state">Ingen bild vald.</div>
-            )}
+            ) : previewError ? (
+              <div className="status-message error">Fel: {previewError}</div>
+            ) : previewLoading ? (
+              <div className="empty-state">Konverterar…</div>
+            ) : previewUrl ? (
+              <img className="culling-image" src={previewUrl} alt={current.basename} />
+            ) : null}
           </div>
         </div>
       )}
     </div>
   );
+}
+
+// RAW extensions that must go through the NEF->JPG preview pipeline
+// (matches file_resolver EXTENSION_PRESETS.raw).
+const RAW_EXTS = ['.nef', '.cr2', '.cr3', '.arw', '.dng', '.raw', '.raf', '.orf', '.rw2'];
+
+function isRaw(p) {
+  const i = p.lastIndexOf('.');
+  return i !== -1 && RAW_EXTS.includes(p.slice(i).toLowerCase());
 }
 
 // file:// URL builder - mirrors ImageViewer.loadImage encoding.


### PR DESCRIPTION
## Summary

Extends the **Gallra spelare** culling workspace to NEF/RAW for "allmän gallring" — general culling that happens before face names are assigned. Builds on the JPEG culling from #46.

### Why it needed more than a flag
General-culling files are `YYMMDD_HHMMSS.NEF` (no `_Name`), so:
- **Listing was name-required.** `culling/files` used the counting core (`build_entries` → `parse_filename`), and the resolver's date filter also needed names, so un-named RAW was silently dropped. Both now fall back to the name-agnostic prefix parser (`extract_filename_datetime`); the CLI counting path is unchanged.
- **RAW can't be shown directly.** The preview pane now resolves RAW via the existing `POST /api/v1/preprocessing/nef` → `nef_jpg_path` → `file://` pipeline (mirrors `ImageViewer`), with a loading state, a stale-result guard, and next-image prefetch for smooth stepping.

### Changes
- Filetype preset selector (jpg / nef / raw) in the culling filter bar.
- `file_resolver` date fallback; `culling_service.list_files` lenient listing (un-named files list, contribute no player-dropdown entries).
- Trash/restore (incl. `.xmp` sidecars) and the cull loop are reused unchanged.
- Docs updated (api-reference + workspace-guide).

## Testing
- Backend verified: un-named `YYMMDD_HHMMSS.NEF` / `-1.NEF` survive date filtering and list sorted by prefix date; player dropdown empty; named JPEG listing and player-count parity unchanged.
- Frontend builds clean.
- **Manual GUI check still needed** for actual NEF→JPG rendering (needs a real `.NEF` + `rawpy` on a display).
