### PR TITLE
Importera: transfer NEF off the camera card + eject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 - **Räkna spelare** module: counts images per named player from filenames (no face recognition) with median-baseline over/under-representation stats; folder/glob input with extension presets and a filename-date span; live auto-refresh when the watched folder changes (#46).
 - **Gallra spelare** culling workspace: filter by player or a Finder-style glob, file list beside a maximized preview, keystroke culling (`x`/Delete) with auto-advance and `Cmd+Z` undo, backed by an app-managed trash with restore-to-original (#46). Extended to NEF/RAW via the existing NEF→JPG preview pipeline, with debounced conversion on fast stepping (#47).
 - Folder-level file-watching IPC and a folder-path dialog, shared by the new modules.
+- **Importera** module: detect the mounted camera card, transfer its NEFs (+ `.xmp` sidecars) to a destination folder with live progress (move or copy, selectable), then eject the card. Skips files already present; ejects only after a zero-error transfer. macOS (`diskutil`) (#48-followup).
 
 ### Changed
 - Documentation: established [CLAUDE.md](CLAUDE.md) as the canonical agent-instructions file; [AGENTS.md](AGENTS.md) and `.github/copilot-instructions.md` now point to it.

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ GUI-onboarding av CLI-skript (en PR per steg):
 
 - [x] **Räkna spelare** — GUI för `rakna_spelare` (bilder per spelare, baseline/avvikelse, mapp/glob/datum, live-uppdatering) (#46)
 - [x] **Gallra spelare** — culling-workspace (spelar/glob-filter, fillista + maximerad preview, snabbtangent-gallring med app-papperskorg + återställning); NEF/RAW-stöd via NEF→JPG-preview (#46/#47)
-- [ ] **Import-modul** — överför NEF från minneskort → målmapp + mata ut (flytta/kopiera väljbart); macOS `diskutil`. Egen PR. (Spec i planfilen.)
+- [x] **Import-modul** — överför NEF från minneskort → målmapp + mata ut (flytta/kopiera väljbart); macOS `diskutil`.
 - [ ] **rename_nef → GUI** — EXIF `CreateDate` → `YYMMDD_HHMMSS.NEF` (+ `-NN` vid krock), preview + bekräfta.
 
 ### Mellan sikt

--- a/backend/api/routes/imports.py
+++ b/backend/api/routes/imports.py
@@ -1,0 +1,51 @@
+"""Import API Routes
+
+Detect camera-card volumes and transfer NEFs off them (+ eject). See
+`import_service`. Module named `imports` because `import` is a reserved word.
+"""
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..services.import_service import import_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ImportRunRequest(BaseModel):
+    volume_mount: str
+    destination: str
+    mode: Literal["move", "copy"] = "move"
+    eject: bool = True
+
+
+@router.get("/import/volumes")
+async def list_volumes():
+    """List ejectable/external card volumes with NEF counts."""
+    try:
+        return {"volumes": import_service.list_volumes()}
+    except Exception as e:
+        logger.exception("Import volume listing failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/import/run")
+async def run_import(request: ImportRunRequest):
+    """Transfer NEFs from the volume to the destination, then eject."""
+    try:
+        return await import_service.run_import(
+            volume_mount=request.volume_mount,
+            destination=request.destination,
+            mode=request.mode,
+            eject=request.eject,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("Import run failed")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -210,13 +210,14 @@ async def health_check():
 API_V1_PREFIX = "/api/v1"
 
 # Import routes
-from .routes import detection, status, database, statistics, management, preprocessing, files, startup, refinement, player_count, culling
+from .routes import detection, status, database, statistics, management, preprocessing, files, startup, refinement, player_count, culling, imports
 app.include_router(detection.router, prefix=API_V1_PREFIX, tags=["detection"])
 app.include_router(status.router, prefix=API_V1_PREFIX, tags=["status"])
 app.include_router(database.router, prefix=API_V1_PREFIX, tags=["database"])
 app.include_router(statistics.router, prefix=API_V1_PREFIX, tags=["statistics"])
 app.include_router(player_count.router, prefix=API_V1_PREFIX, tags=["players"])
 app.include_router(culling.router, prefix=API_V1_PREFIX, tags=["culling"])
+app.include_router(imports.router, prefix=API_V1_PREFIX, tags=["import"])
 app.include_router(management.router, prefix=API_V1_PREFIX, tags=["management"])
 app.include_router(refinement.router, prefix=API_V1_PREFIX, tags=["refinement"])
 app.include_router(preprocessing.router, prefix=f"{API_V1_PREFIX}/preprocessing", tags=["preprocessing"])

--- a/backend/api/services/import_service.py
+++ b/backend/api/services/import_service.py
@@ -110,14 +110,27 @@ class ImportService:
         return count, size
 
     @staticmethod
-    def _free_target(dest: Path, name: str) -> Path:
-        """Next non-colliding target: DSC0001.NEF -> DSC0001-1.NEF, -2, ..."""
+    def _resolve_target(dest: Path, name: str, src: Path) -> Path | None:
+        """Where to write `src`, or None if an identical copy is already present.
+
+        Skips byte-identical re-imports — checking the base name AND any earlier
+        `-N` disambiguation variant (so re-importing is idempotent, no dupes) — and
+        otherwise returns the next free `DSC0001-N.NEF`, so a distinct same-named
+        frame is never dropped.
+        """
+        target = dest / name
+        if not target.exists():
+            return target
+        if _same_file(src, target):
+            return None
         stem, suffix = os.path.splitext(name)
         i = 1
         while True:
             cand = dest / f"{stem}-{i}{suffix}"
             if not cand.exists():
                 return cand
+            if _same_file(src, cand):
+                return None
             i += 1
 
     # ----- transfer -----------------------------------------------------
@@ -157,16 +170,12 @@ class ImportService:
 
         for i, src in enumerate(nefs, 1):
             try:
-                target = dest / src.name
-                if target.exists() and await loop.run_in_executor(None, _same_file, src, target):
-                    # Genuine re-import of the same file — safe to skip.
+                target = await loop.run_in_executor(None, self._resolve_target, dest, src.name, src)
+                if target is None:
+                    # Byte-identical copy already present (base or a -N variant) —
+                    # safe to skip; re-import is idempotent.
                     skipped.append({"path": str(src), "reason": "identisk fil finns redan"})
                 else:
-                    if target.exists():
-                        # A DISTINCT file sharing a camera basename (DCIM rollover
-                        # or a second card into the same folder). Disambiguate
-                        # instead of silently dropping it — never lose a frame.
-                        target = self._free_target(dest, src.name)
                     await loop.run_in_executor(None, op, str(src), str(target))
                     # Carry .xmp sidecars, named after the (possibly renamed) target.
                     for sc in find_sidecar_files(src, SIDECAR_EXTENSIONS):

--- a/backend/api/services/import_service.py
+++ b/backend/api/services/import_service.py
@@ -10,6 +10,7 @@ degrades to an empty volume list / disabled eject elsewhere.
 """
 
 import asyncio
+import filecmp
 import logging
 import os
 import plistlib
@@ -21,6 +22,14 @@ from ..websocket.progress import broadcast_event
 from .rename_service import find_sidecar_files
 
 logger = logging.getLogger(__name__)
+
+
+def _same_file(a: Path, b: Path) -> bool:
+    """True if two files are byte-identical (filecmp short-circuits on size)."""
+    try:
+        return filecmp.cmp(str(a), str(b), shallow=False)
+    except OSError:
+        return False
 
 VOLUMES_ROOT = Path("/Volumes")
 SIDECAR_EXTENSIONS = ["xmp"]
@@ -100,6 +109,17 @@ class ImportService:
             pass
         return count, size
 
+    @staticmethod
+    def _free_target(dest: Path, name: str) -> Path:
+        """Next non-colliding target: DSC0001.NEF -> DSC0001-1.NEF, -2, ..."""
+        stem, suffix = os.path.splitext(name)
+        i = 1
+        while True:
+            cand = dest / f"{stem}-{i}{suffix}"
+            if not cand.exists():
+                return cand
+            i += 1
+
     # ----- transfer -----------------------------------------------------
 
     async def run_import(
@@ -136,15 +156,21 @@ class ImportService:
         loop = asyncio.get_event_loop()
 
         for i, src in enumerate(nefs, 1):
-            target = dest / src.name
             try:
-                if target.exists():
-                    skipped.append({"path": str(src), "reason": "finns redan i målmappen"})
+                target = dest / src.name
+                if target.exists() and await loop.run_in_executor(None, _same_file, src, target):
+                    # Genuine re-import of the same file — safe to skip.
+                    skipped.append({"path": str(src), "reason": "identisk fil finns redan"})
                 else:
+                    if target.exists():
+                        # A DISTINCT file sharing a camera basename (DCIM rollover
+                        # or a second card into the same folder). Disambiguate
+                        # instead of silently dropping it — never lose a frame.
+                        target = self._free_target(dest, src.name)
                     await loop.run_in_executor(None, op, str(src), str(target))
-                    # Carry .xmp sidecars (best-effort; never blocks the main file).
+                    # Carry .xmp sidecars, named after the (possibly renamed) target.
                     for sc in find_sidecar_files(src, SIDECAR_EXTENSIONS):
-                        sc_target = dest / sc.name
+                        sc_target = dest / f"{target.stem}{sc.suffix}"
                         if not sc_target.exists():
                             try:
                                 await loop.run_in_executor(None, op, str(sc), str(sc_target))
@@ -164,7 +190,13 @@ class ImportService:
 
         ejected = False
         if eject and not errors:
-            ejected = await self._eject(volume_mount)
+            # Re-validate ejectable here (defense-in-depth): keep the "never the
+            # internal/boot disk" guarantee local to the destructive call, not only
+            # in list_volumes.
+            if self._is_ejectable(self._diskutil_info(volume_mount)):
+                ejected = await self._eject(volume_mount)
+            else:
+                logger.warning("[Import] eject skipped — volume not ejectable: %s", volume_mount)
 
         return {
             "transferred": transferred,

--- a/backend/api/services/import_service.py
+++ b/backend/api/services/import_service.py
@@ -1,0 +1,192 @@
+"""Import Service
+
+GUI backing for importing NEF off a camera card: detect the mounted card volume,
+transfer its NEFs (+ .xmp sidecars) to a destination folder with live progress,
+and eject the card. Mirrors the user's shell one-liner
+(`find /Volumes/... -iname '*.NEF' -exec mv ... && diskutil eject ...`).
+
+Import-only — renaming (rename_nef) is a separate step. macOS-focused (diskutil);
+degrades to an empty volume list / disabled eject elsewhere.
+"""
+
+import asyncio
+import logging
+import os
+import plistlib
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..websocket.progress import broadcast_event
+from .rename_service import find_sidecar_files
+
+logger = logging.getLogger(__name__)
+
+VOLUMES_ROOT = Path("/Volumes")
+SIDECAR_EXTENSIONS = ["xmp"]
+
+
+class ImportService:
+    """Detect card volumes and transfer NEFs off them."""
+
+    # ----- volume detection ---------------------------------------------
+
+    def list_volumes(self) -> list[dict]:
+        """List ejectable/external volumes under /Volumes with NEF counts.
+
+        Never includes the internal/boot disk. Returns [] on non-macOS or when
+        diskutil is unavailable.
+        """
+        if not VOLUMES_ROOT.is_dir():
+            return []
+        volumes: list[dict] = []
+        for entry in sorted(VOLUMES_ROOT.iterdir()):
+            try:
+                if not entry.is_dir() or entry.is_symlink():
+                    continue
+            except OSError:
+                continue
+            info = self._diskutil_info(str(entry))
+            if not self._is_ejectable(info):
+                continue
+            count, size = self._count_nefs(entry)
+            volumes.append({
+                "name": entry.name,
+                "mount": str(entry),
+                "nef_count": count,
+                "total_bytes": size,
+                "ejectable": True,
+            })
+        return volumes
+
+    def _diskutil_info(self, mount: str) -> dict | None:
+        try:
+            res = subprocess.run(
+                ["diskutil", "info", "-plist", mount],
+                capture_output=True, timeout=15,
+            )
+            if res.returncode != 0:
+                return None
+            return plistlib.loads(res.stdout)
+        except FileNotFoundError:
+            logger.warning("[Import] diskutil not available (non-macOS?)")
+            return None
+        except Exception as e:
+            logger.debug("[Import] diskutil info failed for %s: %s", mount, e)
+            return None
+
+    @staticmethod
+    def _is_ejectable(info: dict | None) -> bool:
+        """Only external/removable, never the internal/boot disk."""
+        if not info:
+            return False
+        if info.get("Internal") is True:
+            return False
+        return bool(info.get("Ejectable") or info.get("RemovableMedia"))
+
+    @staticmethod
+    def _count_nefs(base: Path) -> tuple[int, int]:
+        count = 0
+        size = 0
+        try:
+            for p in base.rglob("*"):
+                if p.is_file() and p.suffix.lower() == ".nef":
+                    count += 1
+                    try:
+                        size += p.stat().st_size
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        return count, size
+
+    # ----- transfer -----------------------------------------------------
+
+    async def run_import(
+        self,
+        volume_mount: str,
+        destination: str,
+        mode: str = "move",
+        eject: bool = True,
+    ) -> dict:
+        """Transfer NEFs (+ sidecars) from the volume to destination, then eject.
+
+        Returns {transferred, skipped, errors, ejected, total}. Never raises on a
+        single-file error (collected in `errors`); ejects only after a zero-error
+        transfer.
+        """
+        if not volume_mount or not destination:
+            raise ValueError("volume_mount och destination krävs.")
+        src_base = Path(volume_mount)
+        if not src_base.is_dir():
+            raise ValueError(f"Volymen finns inte: {volume_mount}")
+
+        dest = Path(os.path.expanduser(destination))
+        dest.mkdir(parents=True, exist_ok=True)
+
+        nefs = sorted(
+            p for p in src_base.rglob("*")
+            if p.is_file() and p.suffix.lower() == ".nef"
+        )
+        total = len(nefs)
+        transferred: list[str] = []
+        skipped: list[dict] = []
+        errors: list[dict] = []
+        op = shutil.move if mode == "move" else shutil.copy2
+        loop = asyncio.get_event_loop()
+
+        for i, src in enumerate(nefs, 1):
+            target = dest / src.name
+            try:
+                if target.exists():
+                    skipped.append({"path": str(src), "reason": "finns redan i målmappen"})
+                else:
+                    await loop.run_in_executor(None, op, str(src), str(target))
+                    # Carry .xmp sidecars (best-effort; never blocks the main file).
+                    for sc in find_sidecar_files(src, SIDECAR_EXTENSIONS):
+                        sc_target = dest / sc.name
+                        if not sc_target.exists():
+                            try:
+                                await loop.run_in_executor(None, op, str(sc), str(sc_target))
+                            except Exception:
+                                logger.exception("[Import] sidecar transfer failed: %s", sc)
+                    transferred.append(str(target))
+            except Exception as e:
+                logger.exception("[Import] transfer failed: %s", src)
+                errors.append({"path": str(src), "error": str(e)})
+            await broadcast_event("import-progress", {
+                "phase": "transfer",
+                "current": i,
+                "total": total,
+                "file": src.name,
+                "percent": round(100 * i / total) if total else 100,
+            })
+
+        ejected = False
+        if eject and not errors:
+            ejected = await self._eject(volume_mount)
+
+        return {
+            "transferred": transferred,
+            "skipped": skipped,
+            "errors": errors,
+            "ejected": ejected,
+            "total": total,
+        }
+
+    async def _eject(self, mount: str) -> bool:
+        loop = asyncio.get_event_loop()
+        try:
+            res = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(["diskutil", "eject", mount], capture_output=True, timeout=60),
+            )
+            if res.returncode != 0:
+                logger.warning("[Import] eject failed for %s: %s", mount, res.stderr.decode(errors="replace"))
+            return res.returncode == 0
+        except Exception as e:
+            logger.warning("[Import] eject error for %s: %s", mount, e)
+            return False
+
+
+import_service = ImportService()

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -737,6 +737,41 @@ Permanently delete trashed items. `{ "ids": [...] }` deletes those ids; omit
 
 ---
 
+## Import
+
+Transfer NEFs off a camera card and eject it. Backs the **Importera** module.
+macOS-only (`diskutil`); the volume list is empty on other platforms.
+
+### `GET /api/v1/import/volumes`
+
+List ejectable/external card volumes (never the internal disk).
+
+**Response:**
+```json
+{ "volumes": [ { "name": "NIKON Z 9", "mount": "/Volumes/NIKON Z 9", "nef_count": 312, "total_bytes": 12884901888, "ejectable": true } ] }
+```
+
+### `POST /api/v1/import/run`
+
+Transfer the volume's NEFs (+ `.xmp` sidecars) to `destination`, then eject.
+Skips files already present in the destination (never overwrites); ejects only
+after a zero-error transfer. Emits `import-progress` over the WebSocket.
+
+**Request:**
+```json
+{ "volume_mount": "/Volumes/NIKON Z 9", "destination": "~/Pictures/nerladdat", "mode": "move", "eject": true }
+```
+`mode` is `move` (default) or `copy`.
+
+**Response:**
+```json
+{ "transferred": ["…/DSC0001.NEF"], "skipped": [{"path":"…","reason":"finns redan i målmappen"}], "errors": [], "ejected": true, "total": 312 }
+```
+
+WebSocket event `import-progress`: `{ "phase": "transfer", "current": 5, "total": 312, "file": "DSC0005.NEF", "percent": 2 }`.
+
+---
+
 ## WebSocket
 
 ### `ws://127.0.0.1:5001/ws/progress`

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -18,6 +18,7 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 | **Log Viewer** | Visa loggar |
 | **Original View** | Jämför med originalfil |
 | **Statistics** | Bearbetningsstatistik |
+| **Importera** | Överför NEF från minneskort till målmapp och matar ut kortet |
 | **Räkna spelare** | Räknar bilder per spelare (från filnamn) med över-/underrepresentation |
 | **Gallra spelare** | Gallra bilder per spelare med förhandsvisning och papperskorg |
 | **Database** | Databashantering |
@@ -90,6 +91,7 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 |--------|----------|
 | `?` | Visa hjälp |
 | `Cmd+O` | Öppna fil |
+| `Cmd+Shift+I` | Importera |
 | `Cmd+Shift+K` | Räkna spelare |
 | `Cmd+Shift+G` | Gallra spelare |
 | `Cmd+,` | Inställningar |
@@ -98,6 +100,12 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 ---
 
 ## Arbetsflöde
+
+### 0. Importera från minneskort (valfritt)
+
+1. Öppna **Importera** (`Cmd+Shift+I`). Modulen listar isatta minneskort med antal NEF.
+2. Välj kort, målmapp (kom ihåg senaste), samt Flytta/Kopiera och om kortet ska matas ut.
+3. Klicka **Importera** — en förloppsindikator visas; kortet matas ut efter felfri överföring.
 
 ### 1. Lägg till filer
 

--- a/frontend/src/main/menu.js
+++ b/frontend/src/main/menu.js
@@ -285,6 +285,13 @@ function createApplicationMenu(mainWindow) {
           }
         },
         {
+          label: 'Importera',
+          accelerator: 'CmdOrCtrl+Shift+I',
+          click: () => {
+            sendMenuCommand('open-import');
+          }
+        },
+        {
           label: 'Räkna spelare',
           accelerator: 'CmdOrCtrl+Shift+K',
           click: () => {

--- a/frontend/src/renderer/components/ImportModule.css
+++ b/frontend/src/renderer/components/ImportModule.css
@@ -1,0 +1,91 @@
+.import-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+  overflow-y: auto;
+}
+
+.import-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.import-label {
+  font-size: 0.85em;
+  color: var(--text-secondary);
+}
+
+.import-empty {
+  color: var(--text-secondary);
+  font-style: italic;
+  padding: 4px 0;
+}
+
+.import-dest-row {
+  display: flex;
+  gap: 8px;
+}
+
+.import-dest {
+  flex: 1;
+  min-width: 0;
+}
+
+.import-radios {
+  display: flex;
+  gap: 16px;
+}
+
+.import-eject {
+  margin-top: -4px;
+}
+
+.import-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.import-hint {
+  font-size: 0.85em;
+  color: var(--text-secondary);
+}
+
+.import-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.import-progress-label {
+  font-size: 0.8em;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.import-result {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  font-size: 0.9em;
+}
+
+.import-ok { color: var(--success, #3ba55d); }
+.import-warn { color: var(--warning, #d9a441); }
+
+.import-errors {
+  font-size: 0.85em;
+  color: var(--error, #d65b5b);
+}
+
+.import-errors ul {
+  margin: 4px 0 0 16px;
+  padding: 0;
+}

--- a/frontend/src/renderer/components/ImportModule.jsx
+++ b/frontend/src/renderer/components/ImportModule.jsx
@@ -1,0 +1,218 @@
+/**
+ * ImportModule - Transfer NEF off a camera card + eject.
+ *
+ * GUI for the import step: pick a detected card volume and a destination, choose
+ * move/copy, transfer all NEFs (+ .xmp sidecars) with live progress, then eject.
+ * Import-only — renaming (rename_nef) is a separate step.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useBackend } from '../context/BackendContext.jsx';
+import { useWebSocket } from '../hooks/useWebSocket.js';
+import { preferences } from '../workspace/preferences.js';
+import { ProgressBar } from './ProgressBar.jsx';
+import './ImportModule.css';
+
+const DEFAULT_DEST = '~/Pictures/nerladdat';
+const isMac = navigator.platform.toLowerCase().includes('mac');
+
+export function ImportModule() {
+  const { api } = useBackend();
+
+  const [volumes, setVolumes] = useState([]);
+  const [selectedMount, setSelectedMount] = useState('');
+  const [destination, setDestination] = useState(
+    () => preferences.get('import.destination') || DEFAULT_DEST
+  );
+  const [mode, setMode] = useState('move');
+  const [eject, setEject] = useState(isMac);
+
+  const [loadingVolumes, setLoadingVolumes] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState(null);
+  const [progressLabel, setProgressLabel] = useState('');
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+
+  const loadVolumes = useCallback(async () => {
+    setLoadingVolumes(true);
+    try {
+      const data = await api.get('/api/v1/import/volumes');
+      const vols = data.volumes || [];
+      setVolumes(vols);
+      setSelectedMount((prev) => {
+        if (prev && vols.some((v) => v.mount === prev)) return prev;
+        return vols[0]?.mount || '';
+      });
+      setError(null);
+    } catch (err) {
+      setError(err.message || String(err));
+    } finally {
+      setLoadingVolumes(false);
+    }
+  }, [api]);
+
+  useEffect(() => { loadVolumes(); }, [loadVolumes]);
+
+  // Live progress.
+  const onProgress = useCallback((data) => {
+    if (!data) return;
+    setProgress(data.percent ?? null);
+    setProgressLabel(`${data.current}/${data.total} · ${data.file || ''}`);
+  }, []);
+  useWebSocket('import-progress', onProgress);
+
+  const pickDestination = useCallback(async () => {
+    try {
+      const paths = await window.ansiktenAPI.invoke('open-folder-paths');
+      if (paths && paths.length) {
+        setDestination(paths[0]);
+        preferences.set('import.destination', paths[0]);
+      }
+    } catch (err) {
+      console.error('[Import] folder pick failed', err);
+    }
+  }, []);
+
+  const onDestinationChange = useCallback((e) => {
+    setDestination(e.target.value);
+    preferences.set('import.destination', e.target.value);
+  }, []);
+
+  const runImport = useCallback(async () => {
+    if (!selectedMount || !destination.trim()) return;
+    setRunning(true);
+    setResult(null);
+    setError(null);
+    setProgress(0);
+    setProgressLabel('');
+    try {
+      const res = await api.post('/api/v1/import/run', {
+        volume_mount: selectedMount,
+        destination: destination.trim(),
+        mode,
+        eject,
+      });
+      setResult(res);
+      loadVolumes(); // card is likely gone after eject; refresh the list
+    } catch (err) {
+      setError(err.message || String(err));
+    } finally {
+      setRunning(false);
+      setProgress(null);
+    }
+  }, [api, selectedMount, destination, mode, eject, loadVolumes]);
+
+  const selected = volumes.find((v) => v.mount === selectedMount);
+  const canRun = !running && !!selectedMount && destination.trim() !== '';
+
+  return (
+    <div className="module-container import">
+      <div className="module-header">
+        <h3 className="module-title">Importera</h3>
+        <div className="button-group">
+          <button className="btn-secondary" onClick={loadVolumes} disabled={loadingVolumes || running}>
+            {loadingVolumes ? '…' : 'Uppdatera'}
+          </button>
+        </div>
+      </div>
+
+      <div className="module-body import-body">
+        {error && <div className="status-message error">Fel: {error}</div>}
+
+        <label className="import-field">
+          <span className="import-label">Minneskort</span>
+          {volumes.length === 0 ? (
+            <span className="import-empty">{loadingVolumes ? 'Söker…' : 'Inget minneskort hittat'}</span>
+          ) : (
+            <select
+              className="form-select"
+              value={selectedMount}
+              onChange={(e) => setSelectedMount(e.target.value)}
+              disabled={running}
+            >
+              {volumes.map((v) => (
+                <option key={v.mount} value={v.mount}>
+                  {v.name} — {v.nef_count} NEF ({formatBytes(v.total_bytes)})
+                </option>
+              ))}
+            </select>
+          )}
+        </label>
+
+        <label className="import-field">
+          <span className="import-label">Målmapp</span>
+          <span className="import-dest-row">
+            <input
+              className="form-input import-dest"
+              type="text"
+              value={destination}
+              onChange={onDestinationChange}
+              disabled={running}
+            />
+            <button className="btn-secondary" onClick={pickDestination} disabled={running}>Välj…</button>
+          </span>
+        </label>
+
+        <div className="import-field">
+          <span className="import-label">Överföring</span>
+          <span className="import-radios">
+            <label className="form-checkbox">
+              <input type="radio" name="mode" checked={mode === 'move'} onChange={() => setMode('move')} disabled={running} />
+              Flytta
+            </label>
+            <label className="form-checkbox">
+              <input type="radio" name="mode" checked={mode === 'copy'} onChange={() => setMode('copy')} disabled={running} />
+              Kopiera
+            </label>
+          </span>
+        </div>
+
+        <label className="form-checkbox import-eject">
+          <input type="checkbox" checked={eject} onChange={(e) => setEject(e.target.checked)} disabled={running || !isMac} />
+          Mata ut efter överföring{!isMac && ' (endast macOS)'}
+        </label>
+
+        <div className="import-actions">
+          <button className="btn-primary" onClick={runImport} disabled={!canRun}>
+            {running ? 'Importerar…' : 'Importera'}
+          </button>
+          {selected && !running && (
+            <span className="import-hint">{selected.nef_count} NEF redo att {mode === 'move' ? 'flyttas' : 'kopieras'}</span>
+          )}
+        </div>
+
+        {running && (
+          <div className="import-progress">
+            <ProgressBar value={progress} size="md" showPercent />
+            <span className="import-progress-label">{progressLabel}</span>
+          </div>
+        )}
+
+        {result && !running && (
+          <div className="import-result">
+            <div><strong>{result.transferred.length}</strong> överförda{result.skipped.length > 0 && `, ${result.skipped.length} överhoppade`}</div>
+            {result.ejected
+              ? <div className="import-ok">Kortet utmatat ✓</div>
+              : (eject && <div className="import-warn">Kortet ej utmatat</div>)}
+            {result.errors.length > 0 && (
+              <details className="import-errors">
+                <summary>{result.errors.length} fel</summary>
+                <ul>{result.errors.map((e, i) => <li key={i}>{e.path}: {e.error}</li>)}</ul>
+              </details>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatBytes(n) {
+  if (!n) return '0 B';
+  const u = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(u.length - 1, Math.floor(Math.log(n) / Math.log(1024)));
+  return `${(n / Math.pow(1024, i)).toFixed(i ? 1 : 0)} ${u[i]}`;
+}
+
+export default ImportModule;

--- a/frontend/src/renderer/components/index.js
+++ b/frontend/src/renderer/components/index.js
@@ -8,6 +8,7 @@ export { LogViewer } from './LogViewer.jsx';
 export { StatisticsDashboard } from './StatisticsDashboard.jsx';
 export { PlayerCountModule } from './PlayerCountModule.jsx';
 export { CullingModule } from './CullingModule.jsx';
+export { ImportModule } from './ImportModule.jsx';
 export { ReviewModule } from './ReviewModule.jsx';
 export { DatabaseManagement } from './DatabaseManagement.jsx';
 export { StartupStatus } from './StartupStatus.jsx';

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -26,6 +26,7 @@ import { PreferencesModule } from '../../components/PreferencesModule.jsx';
 import { RefineFacesModule } from '../../components/RefineFacesModule.jsx';
 import { PlayerCountModule } from '../../components/PlayerCountModule.jsx';
 import { CullingModule } from '../../components/CullingModule.jsx';
+import { ImportModule } from '../../components/ImportModule.jsx';
 
 
 // Storage key for layout persistence
@@ -178,7 +179,8 @@ const MODULE_COMPONENTS = {
   'theme-editor': ThemeEditor,
   'preferences': PreferencesModule,
   'player-count': PlayerCountModule,
-  'culling': CullingModule
+  'culling': CullingModule,
+  'import': ImportModule
 };
 
 // Module titles
@@ -194,7 +196,8 @@ const MODULE_TITLES = {
   'theme-editor': 'Theme Editor',
   'preferences': 'Preferences',
   'player-count': 'Räkna spelare',
-  'culling': 'Gallra spelare'
+  'culling': 'Gallra spelare',
+  'import': 'Importera'
 };
 
 // Module-specific default layout ratios
@@ -249,6 +252,11 @@ const MODULE_LAYOUT = {
   },
   'culling': {
     widthRatio: 0.70,     // wide - it holds list + image side by side
+    heightRatio: 0.70,    // Primary row
+    row: 1
+  },
+  'import': {
+    widthRatio: 0.40,     // compact form
     heightRatio: 0.70,    // Primary row
     row: 1
   }
@@ -472,7 +480,8 @@ export function FlexLayoutWorkspace() {
     'refine-faces',
     'theme-editor',
     'player-count',
-    'culling'
+    'culling',
+    'import'
   ]);
 
   // Open a module tab
@@ -1138,6 +1147,9 @@ export function FlexLayoutWorkspace() {
           break;
         case 'open-culling':
           openModule('culling');
+          break;
+        case 'open-import':
+          openModule('import');
           break;
         case 'open-database-management':
           openModule('database-management');


### PR DESCRIPTION
## Summary
GUI for the import step of the workflow: detect the mounted camera card, transfer its NEFs (+ `.xmp` sidecars) to a destination folder with live progress, then eject. Mirrors the user's `find … -iname '*.NEF' -exec mv … && diskutil eject …` one-liner. **Import-only** — `rename_nef` is a separate next step.

### Backend
- `import_service.list_volumes()` — ejectable/external `/Volumes` entries (never the boot disk, via `diskutil info -plist`), with NEF counts/sizes.
- `import_service.run_import()` — move (`shutil.move`) or copy (`shutil.copy2`) per file, carries `.xmp` sidecars, **skips existing targets** (never overwrites), emits `import-progress` over the WebSocket, and ejects via `diskutil` **only after a zero-error transfer**.
- Routes `GET /api/v1/import/volumes`, `POST /api/v1/import/run`.

### Frontend
- **Importera** module: volume list, destination picker (remembered last-used, default `~/Pictures/nerladdat`), move/copy radio, eject toggle (macOS), `ProgressBar` from `import-progress`, result summary. Menu + `Cmd+Shift+I`.

### Safety
Only ejectable/external volumes listed; eject gated on zero errors; no overwrite; `shutil.move` for cross-filesystem card→disk.

## Testing
- Backend verified with a synthetic card dir: move/copy, `.xmp` carried, source emptied (move), progress events emitted, re-run skips existing. `list_volumes()` excludes the boot disk.
- Frontend builds clean; event names + IPC verified both ends.
- **Manual GUI/hardware check still needed** for real card detection + `diskutil eject` (needs a card on macOS).

macOS-only (`diskutil`); degrades to an empty volume list elsewhere.
