### PR TITLE
Byt namn: EXIF-based NEF renaming (rename_nef GUI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 - **Gallra spelare** culling workspace: filter by player or a Finder-style glob, file list beside a maximized preview, keystroke culling (`x`/Delete) with auto-advance and `Cmd+Z` undo, backed by an app-managed trash with restore-to-original (#46). Extended to NEF/RAW via the existing NEF→JPG preview pipeline, with debounced conversion on fast stepping (#47).
 - Folder-level file-watching IPC and a folder-path dialog, shared by the new modules.
 - **Importera** module: detect the mounted camera card, transfer its NEFs (+ `.xmp` sidecars) to a destination folder with live progress (move or copy, selectable), then eject the card. Skips files already present; ejects only after a zero-error transfer. macOS (`diskutil`) (#48-followup).
+- **Byt namn** module: rename NEFs from EXIF `CreateDate` to `YYMMDD_HHMMSS.NEF` (rename_nef GUI), with a preview (dry-run) and confirm. Carries `.xmp` sidecars, disambiguates identical timestamps (`-NN`), skips files without a `CreateDate`, and never overwrites an existing target (restores the original on collision).
 
 ### Changed
 - Documentation: established [CLAUDE.md](CLAUDE.md) as the canonical agent-instructions file; [AGENTS.md](AGENTS.md) and `.github/copilot-instructions.md` now point to it.

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@ GUI-onboarding av CLI-skript (en PR per steg):
 - [x] **Räkna spelare** — GUI för `rakna_spelare` (bilder per spelare, baseline/avvikelse, mapp/glob/datum, live-uppdatering) (#46)
 - [x] **Gallra spelare** — culling-workspace (spelar/glob-filter, fillista + maximerad preview, snabbtangent-gallring med app-papperskorg + återställning); NEF/RAW-stöd via NEF→JPG-preview (#46/#47)
 - [x] **Import-modul** — överför NEF från minneskort → målmapp + mata ut (flytta/kopiera väljbart); macOS `diskutil`.
-- [ ] **rename_nef → GUI** — EXIF `CreateDate` → `YYMMDD_HHMMSS.NEF` (+ `-NN` vid krock), preview + bekräfta.
+- [x] **rename_nef → GUI** — EXIF `CreateDate` → `YYMMDD_HHMMSS.NEF` (+ `-NN` vid krock), preview + bekräfta.
 
 ### Mellan sikt
 

--- a/backend/api/routes/rename_nef.py
+++ b/backend/api/routes/rename_nef.py
@@ -1,0 +1,51 @@
+"""Rename-NEF API Routes
+
+EXIF-based NEF renaming (YYMMDD_HHMMSS.NEF) with preview/confirm. See
+`rename_nef_service`.
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..services.rename_nef_service import rename_nef_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class RenameNefRequest(BaseModel):
+    roots: List[str] = []
+    globs: List[str] = []
+    recursive: bool = True
+
+
+@router.post("/rename-nef/preview")
+async def preview(request: RenameNefRequest):
+    """Dry-run: show the EXIF-derived rename mapping."""
+    try:
+        return rename_nef_service.preview(
+            roots=request.roots, globs=request.globs, recursive=request.recursive,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("rename-nef preview failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/rename-nef/execute")
+async def execute(request: RenameNefRequest):
+    """Rename the NEFs (+ sidecars) from EXIF CreateDate."""
+    try:
+        return rename_nef_service.execute(
+            roots=request.roots, globs=request.globs, recursive=request.recursive,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("rename-nef execute failed")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -210,7 +210,7 @@ async def health_check():
 API_V1_PREFIX = "/api/v1"
 
 # Import routes
-from .routes import detection, status, database, statistics, management, preprocessing, files, startup, refinement, player_count, culling, imports
+from .routes import detection, status, database, statistics, management, preprocessing, files, startup, refinement, player_count, culling, imports, rename_nef
 app.include_router(detection.router, prefix=API_V1_PREFIX, tags=["detection"])
 app.include_router(status.router, prefix=API_V1_PREFIX, tags=["status"])
 app.include_router(database.router, prefix=API_V1_PREFIX, tags=["database"])
@@ -218,6 +218,7 @@ app.include_router(statistics.router, prefix=API_V1_PREFIX, tags=["statistics"])
 app.include_router(player_count.router, prefix=API_V1_PREFIX, tags=["players"])
 app.include_router(culling.router, prefix=API_V1_PREFIX, tags=["culling"])
 app.include_router(imports.router, prefix=API_V1_PREFIX, tags=["import"])
+app.include_router(rename_nef.router, prefix=API_V1_PREFIX, tags=["rename-nef"])
 app.include_router(management.router, prefix=API_V1_PREFIX, tags=["management"])
 app.include_router(refinement.router, prefix=API_V1_PREFIX, tags=["refinement"])
 app.include_router(preprocessing.router, prefix=f"{API_V1_PREFIX}/preprocessing", tags=["preprocessing"])

--- a/backend/api/services/rename_nef_service.py
+++ b/backend/api/services/rename_nef_service.py
@@ -1,0 +1,130 @@
+"""Rename-NEF Service
+
+GUI backing for the rename_nef CLI: rename NEFs from EXIF CreateDate to
+YYMMDD_HHMMSS.NEF, with a preview (dry-run) and a confirm (execute). Reuses the
+CLI's EXIF read + duplicate-timestamp disambiguation; reimplements the two-pass
+execute to return structured results, carry .xmp sidecars, and — unlike the CLI —
+restore (never delete) the original when a target name is already taken.
+"""
+
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+# Backend root on sys.path to import the CLI core.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from rename_nef import compute_renames, get_exif_data  # noqa: E402
+
+from .file_resolver import preset_extensions, resolve_files  # noqa: E402
+from .rename_service import find_sidecar_files  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+SIDECAR_EXTENSIONS = ["xmp"]
+# A usable capture timestamp must be exactly YYMMDD_HHMMSS. exiftool's
+# `-if defined $CreateDate` can still let a blank/zero date through (→ ts ""),
+# which would otherwise rename a file to just ".NEF" — guard against that.
+_VALID_TS = re.compile(r"^\d{6}_\d{6}$")
+
+
+class RenameNefService:
+    """Preview and execute EXIF-based NEF renaming."""
+
+    def _resolve(self, roots, globs, recursive):
+        roots = roots or []
+        globs = globs or []
+        if not roots and not globs:
+            raise ValueError("Ange minst en mapp eller ett glob-mönster.")
+        return resolve_files(
+            roots=roots, globs=globs,
+            extensions=preset_extensions("nef"), recursive=recursive,
+        )
+
+    def _plan(self, files):
+        """Return (renames, no_date_names, valid_count) from the resolved files.
+
+        Only entries with a well-formed YYMMDD_HHMMSS timestamp are eligible;
+        everything else (no/blank CreateDate) is reported as no_date and never
+        renamed.
+        """
+        try:
+            entries = get_exif_data([Path(f) for f in files])
+        except FileNotFoundError:
+            raise ValueError("exiftool krävs men hittades inte i PATH.")
+        valid = [(ts, sub, p) for ts, sub, p in entries if _VALID_TS.match(ts or "")]
+        dated = {str(p) for _, _, p in valid}
+        no_date = [Path(f).name for f in files if f not in dated]
+        renames = compute_renames(valid)
+        return renames, no_date, len(valid)
+
+    def preview(self, roots=None, globs=None, recursive=True) -> dict:
+        files = self._resolve(roots, globs, recursive)
+        renames, no_date, valid_count = self._plan(files)
+        return {
+            "items": [
+                {"original_path": str(src), "original": src.name, "new_name": dst.name}
+                for src, dst, _ in renames
+            ],
+            "total_files": len(files),
+            "to_rename": len(renames),
+            "already_named": valid_count - len(renames),  # had a date but were no-ops
+            "no_date": no_date,
+        }
+
+    def execute(self, roots=None, globs=None, recursive=True) -> dict:
+        files = self._resolve(roots, globs, recursive)
+        renames, _no_date, _valid = self._plan(files)
+
+        # Build the full move list: each NEF plus its .xmp sidecar, with fresh
+        # unique temp names (two-pass avoids intra-batch collisions).
+        stamp = str(os.getpid())
+        full: list[tuple[Path, Path, Path]] = []
+        ctr = 0
+        for src, dst, _tmp in renames:
+            full.append((src, dst, src.parent / f".rename_tmp_{stamp}_{ctr}{src.suffix}"))
+            ctr += 1
+            for sc in find_sidecar_files(src, SIDECAR_EXTENSIONS):
+                sc_dst = dst.with_name(f"{dst.stem}{sc.suffix}")
+                if sc.name == sc_dst.name:
+                    continue
+                full.append((sc, sc_dst, sc.parent / f".rename_tmp_{stamp}_{ctr}{sc.suffix}"))
+                ctr += 1
+
+        renamed: list[dict] = []
+        skipped: list[dict] = []
+        errors: list[dict] = []
+
+        # Pass 1: src -> temp.
+        moved: list[tuple[Path, Path, Path]] = []
+        for src, dst, tmp in full:
+            try:
+                src.rename(tmp)
+                moved.append((src, dst, tmp))
+            except OSError as e:
+                logger.error("[RenameNef] to-temp failed: %s -> %s: %s", src, tmp, e)
+                errors.append({"path": str(src), "error": str(e)})
+
+        # Pass 2: temp -> dst, never overwriting (restore the original on collision).
+        for src, dst, tmp in moved:
+            if dst.exists():
+                try:
+                    tmp.rename(src)  # restore — do NOT delete (CLI bug)
+                    skipped.append({"path": str(src), "reason": f"målnamn upptaget: {dst.name}"})
+                except OSError as e:
+                    logger.error("[RenameNef] restore failed: %s -> %s: %s", tmp, src, e)
+                    errors.append({"path": str(tmp), "error": f"kunde inte återställa: {e}"})
+                continue
+            try:
+                tmp.rename(dst)
+                renamed.append({"from": src.name, "to": dst.name})
+            except OSError as e:
+                logger.error("[RenameNef] to-final failed: %s -> %s: %s", tmp, dst, e)
+                errors.append({"path": str(tmp), "error": str(e)})
+
+        return {"renamed": renamed, "skipped": skipped, "errors": errors}
+
+
+rename_nef_service = RenameNefService()

--- a/backend/api/services/rename_nef_service.py
+++ b/backend/api/services/rename_nef_service.py
@@ -107,24 +107,42 @@ class RenameNefService:
                 logger.error("[RenameNef] to-temp failed: %s -> %s: %s", src, tmp, e)
                 errors.append({"path": str(src), "error": str(e)})
 
-        # Pass 2: temp -> dst, never overwriting (restore the original on collision).
+        # Pass 2: temp -> dst, never overwriting; restore the original on collision.
         for src, dst, tmp in moved:
             if dst.exists():
-                try:
-                    tmp.rename(src)  # restore — do NOT delete (CLI bug)
+                if self._restore(tmp, src):
                     skipped.append({"path": str(src), "reason": f"målnamn upptaget: {dst.name}"})
-                except OSError as e:
-                    logger.error("[RenameNef] restore failed: %s -> %s: %s", tmp, src, e)
-                    errors.append({"path": str(tmp), "error": f"kunde inte återställa: {e}"})
+                else:
+                    errors.append({"path": str(tmp), "error": f"kan ej återställa: {src.name} upptaget — fil kvar som {tmp.name}"})
                 continue
             try:
                 tmp.rename(dst)
                 renamed.append({"from": src.name, "to": dst.name})
             except OSError as e:
                 logger.error("[RenameNef] to-final failed: %s -> %s: %s", tmp, dst, e)
-                errors.append({"path": str(tmp), "error": str(e)})
+                if self._restore(tmp, src):
+                    errors.append({"path": str(src), "error": str(e)})
+                else:
+                    errors.append({"path": str(tmp), "error": f"{e}; kunde ej återställa (fil kvar som {tmp.name})"})
 
         return {"renamed": renamed, "skipped": skipped, "errors": errors}
+
+    @staticmethod
+    def _restore(tmp: Path, src: Path) -> bool:
+        """Move a temp back to its original name, NEVER overwriting an existing file.
+
+        Returns False (leaving the temp in place) if `src` is occupied — better a
+        recoverable hidden temp than silently clobbering a sibling already placed
+        at that name in this same pass.
+        """
+        if src.exists():
+            return False
+        try:
+            tmp.rename(src)
+            return True
+        except OSError as e:
+            logger.error("[RenameNef] restore failed: %s -> %s: %s", tmp, src, e)
+            return False
 
 
 rename_nef_service = RenameNefService()

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -772,6 +772,38 @@ WebSocket event `import-progress`: `{ "phase": "transfer", "current": 5, "total"
 
 ---
 
+## Rename NEF
+
+EXIF-based NEF renaming (`YYMMDD_HHMMSS.NEF`) with preview/confirm. Backs the
+**Byt namn** module. Requires `exiftool`.
+
+### `POST /api/v1/rename-nef/preview`
+
+Dry-run: resolve NEFs (folder/glob) and return the EXIF-derived rename mapping.
+Request `{ roots, globs, recursive }`.
+
+**Response:**
+```json
+{
+  "items": [ { "original_path": "…/DSC0001.NEF", "original": "DSC0001.NEF", "new_name": "250601_100000.NEF" } ],
+  "total_files": 12, "to_rename": 10, "already_named": 1, "no_date": ["DSC9999.NEF"]
+}
+```
+`no_date` = files without a usable `CreateDate` (never renamed). Identical
+timestamps are disambiguated with `-NN`.
+
+### `POST /api/v1/rename-nef/execute`
+
+Rename the NEFs (+ `.xmp` sidecars) from EXIF. Recomputes from current EXIF (no
+stale plan); two-pass via temp files; **never overwrites** — on a target-name
+collision the original is restored and reported as skipped.
+
+**Response:** `{ "renamed": [{"from":"DSC0001.NEF","to":"250601_100000.NEF"}], "skipped": [{"path":"…","reason":"…"}], "errors": [] }`.
+
+`400` if no input or exiftool is missing.
+
+---
+
 ## WebSocket
 
 ### `ws://127.0.0.1:5001/ws/progress`

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -19,6 +19,7 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 | **Original View** | Jämför med originalfil |
 | **Statistics** | Bearbetningsstatistik |
 | **Importera** | Överför NEF från minneskort till målmapp och matar ut kortet |
+| **Byt namn** | Döper om NEF efter EXIF CreateDate (YYMMDD_HHMMSS) med förhandsvisning |
 | **Räkna spelare** | Räknar bilder per spelare (från filnamn) med över-/underrepresentation |
 | **Gallra spelare** | Gallra bilder per spelare med förhandsvisning och papperskorg |
 | **Database** | Databashantering |
@@ -92,6 +93,7 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 | `?` | Visa hjälp |
 | `Cmd+O` | Öppna fil |
 | `Cmd+Shift+I` | Importera |
+| `Cmd+Shift+B` | Byt namn (NEF) |
 | `Cmd+Shift+K` | Räkna spelare |
 | `Cmd+Shift+G` | Gallra spelare |
 | `Cmd+,` | Inställningar |
@@ -106,6 +108,12 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 1. Öppna **Importera** (`Cmd+Shift+I`). Modulen listar isatta minneskort med antal NEF.
 2. Välj kort, målmapp (kom ihåg senaste), samt Flytta/Kopiera och om kortet ska matas ut.
 3. Klicka **Importera** — en förloppsindikator visas; kortet matas ut efter felfri överföring.
+
+### 0b. Byt namn på NEF (valfritt)
+
+1. Öppna **Byt namn** (`Cmd+Shift+B`), välj mappen (ev. glob `DSC*`).
+2. **Förhandsgranska** visar `DSC… → YYMMDD_HHMMSS.NEF` (dubbletter får `-NN`; filer utan CreateDate döps ej om).
+3. **Byt namn** utför; befintliga målnamn skrivs aldrig över.
 
 ### 1. Lägg till filer
 

--- a/frontend/src/main/menu.js
+++ b/frontend/src/main/menu.js
@@ -292,6 +292,13 @@ function createApplicationMenu(mainWindow) {
           }
         },
         {
+          label: 'Byt namn (NEF)',
+          accelerator: 'CmdOrCtrl+Shift+B',
+          click: () => {
+            sendMenuCommand('open-rename-nef');
+          }
+        },
+        {
           label: 'Räkna spelare',
           accelerator: 'CmdOrCtrl+Shift+K',
           click: () => {

--- a/frontend/src/renderer/components/RenameNefModule.css
+++ b/frontend/src/renderer/components/RenameNefModule.css
@@ -1,0 +1,103 @@
+.rename-nef {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.rename-nef-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  flex-wrap: wrap;
+}
+
+.rename-nef-glob {
+  flex: 1 1 200px;
+  min-width: 140px;
+}
+
+.rename-nef-roots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.rename-nef-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  border-radius: 12px;
+  background: var(--bg-tertiary, var(--bg-primary));
+  border: 1px solid var(--border-color);
+  font-size: 0.8em;
+}
+
+.rename-nef-chip-x {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+.rename-nef-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.rename-nef-summary {
+  margin-bottom: 10px;
+  font-size: 0.9em;
+}
+
+.rename-nef-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+}
+
+.rename-nef-table th,
+.rename-nef-table td {
+  padding: 3px 8px;
+  text-align: left;
+}
+
+.rename-nef-table th {
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.rename-nef-arrow {
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.rename-nef-table tbody tr:hover {
+  background: var(--bg-secondary);
+}
+
+.rename-nef-nodate,
+.rename-nef-result {
+  margin-top: 12px;
+  font-size: 0.85em;
+}
+
+.rename-nef-nodate ul,
+.rename-nef-result ul {
+  margin: 4px 0 0 16px;
+  padding: 0;
+  color: var(--text-secondary);
+}
+
+.rename-nef-errors {
+  color: var(--error, #d65b5b);
+}

--- a/frontend/src/renderer/components/RenameNefModule.jsx
+++ b/frontend/src/renderer/components/RenameNefModule.jsx
@@ -1,0 +1,169 @@
+/**
+ * RenameNefModule - EXIF-based NEF renaming (YYMMDD_HHMMSS.NEF).
+ *
+ * GUI for the rename_nef CLI: pick a folder (optionally narrow by glob), preview
+ * the EXIF-derived rename mapping, then confirm. Preview is the dry-run; execute
+ * renames NEFs (+ .xmp sidecars), never overwriting an existing target.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { useBackend } from '../context/BackendContext.jsx';
+import './RenameNefModule.css';
+
+export function RenameNefModule() {
+  const { api } = useBackend();
+
+  const [roots, setRoots] = useState([]);
+  const [glob, setGlob] = useState('');
+  const [preview, setPreview] = useState(null);
+  const [result, setResult] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  const params = useCallback(() => ({
+    roots,
+    globs: glob.trim() ? [glob.trim()] : [],
+    recursive: true,
+  }), [roots, glob]);
+
+  const addFolder = useCallback(async () => {
+    try {
+      const paths = await window.ansiktenAPI.invoke('open-folder-paths');
+      if (paths && paths.length) {
+        setRoots((r) => Array.from(new Set([...r, ...paths])));
+        setPreview(null);
+        setResult(null);
+      }
+    } catch (err) {
+      console.error('[RenameNef] folder pick failed', err);
+    }
+  }, []);
+
+  const doPreview = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const data = await api.post('/api/v1/rename-nef/preview', params());
+      setPreview(data);
+    } catch (err) {
+      setError(err.message || String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [api, params]);
+
+  const doExecute = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const data = await api.post('/api/v1/rename-nef/execute', params());
+      setResult(data);
+      setPreview(null);
+    } catch (err) {
+      setError(err.message || String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [api, params]);
+
+  const canPreview = !busy && (roots.length > 0 || glob.trim() !== '');
+  const canExecute = !busy && preview && preview.to_rename > 0;
+
+  return (
+    <div className="module-container rename-nef">
+      <div className="rename-nef-bar">
+        <button className="btn-secondary" onClick={addFolder} disabled={busy}>+ Mapp</button>
+        <input
+          className="form-input rename-nef-glob"
+          type="text"
+          placeholder="Glob (valfritt), t.ex. DSC*"
+          value={glob}
+          onChange={(e) => { setGlob(e.target.value); }}
+          onKeyDown={(e) => { if (e.key === 'Enter') canPreview && doPreview(); }}
+          disabled={busy}
+        />
+        <button className="btn-secondary" onClick={doPreview} disabled={!canPreview}>
+          {busy ? '…' : 'Förhandsgranska'}
+        </button>
+        <button className="btn-primary" onClick={doExecute} disabled={!canExecute}>
+          Byt namn
+        </button>
+      </div>
+
+      {roots.length > 0 && (
+        <div className="rename-nef-roots">
+          {roots.map((r) => (
+            <span className="rename-nef-chip" key={r} title={r}>
+              {basename(r)}
+              <button className="rename-nef-chip-x" onClick={() => { setRoots((rs) => rs.filter((x) => x !== r)); setPreview(null); }} disabled={busy}>×</button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="module-body rename-nef-body">
+        {error && <div className="status-message error">Fel: {error}</div>}
+
+        {!preview && !result && !error && (
+          <div className="empty-state">Välj en mapp och tryck <strong>Förhandsgranska</strong>.</div>
+        )}
+
+        {preview && (
+          <>
+            <div className="rename-nef-summary">
+              <strong>{preview.to_rename}</strong> att döpa om
+              {preview.already_named > 0 && <> · {preview.already_named} redan namngivna</>}
+              {preview.no_date.length > 0 && <> · {preview.no_date.length} utan CreateDate</>}
+            </div>
+            {preview.to_rename === 0 ? (
+              <div className="empty-state">Inget att döpa om.</div>
+            ) : (
+              <table className="rename-nef-table">
+                <thead><tr><th>Original</th><th></th><th>Nytt namn</th></tr></thead>
+                <tbody>
+                  {preview.items.map((it) => (
+                    <tr key={it.original_path}>
+                      <td>{it.original}</td>
+                      <td className="rename-nef-arrow">→</td>
+                      <td>{it.new_name}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            {preview.no_date.length > 0 && (
+              <details className="rename-nef-nodate">
+                <summary>{preview.no_date.length} utan CreateDate (döps ej om)</summary>
+                <ul>{preview.no_date.map((n) => <li key={n}>{n}</li>)}</ul>
+              </details>
+            )}
+          </>
+        )}
+
+        {result && (
+          <div className="rename-nef-result">
+            <div><strong>{result.renamed.length}</strong> omdöpta{result.skipped.length > 0 && `, ${result.skipped.length} överhoppade`}</div>
+            {result.skipped.length > 0 && (
+              <details><summary>Överhoppade</summary>
+                <ul>{result.skipped.map((s, i) => <li key={i}>{basename(s.path)}: {s.reason}</li>)}</ul>
+              </details>
+            )}
+            {result.errors.length > 0 && (
+              <details className="rename-nef-errors"><summary>{result.errors.length} fel</summary>
+                <ul>{result.errors.map((e, i) => <li key={i}>{e.path}: {e.error}</li>)}</ul>
+              </details>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function basename(p) {
+  const parts = String(p).replace(/\/+$/, '').split('/');
+  return parts[parts.length - 1] || p;
+}
+
+export default RenameNefModule;

--- a/frontend/src/renderer/components/RenameNefModule.jsx
+++ b/frontend/src/renderer/components/RenameNefModule.jsx
@@ -79,7 +79,7 @@ export function RenameNefModule() {
           type="text"
           placeholder="Glob (valfritt), t.ex. DSC*"
           value={glob}
-          onChange={(e) => { setGlob(e.target.value); }}
+          onChange={(e) => { setGlob(e.target.value); setPreview(null); setResult(null); }}
           onKeyDown={(e) => { if (e.key === 'Enter') canPreview && doPreview(); }}
           disabled={busy}
         />

--- a/frontend/src/renderer/components/index.js
+++ b/frontend/src/renderer/components/index.js
@@ -9,6 +9,7 @@ export { StatisticsDashboard } from './StatisticsDashboard.jsx';
 export { PlayerCountModule } from './PlayerCountModule.jsx';
 export { CullingModule } from './CullingModule.jsx';
 export { ImportModule } from './ImportModule.jsx';
+export { RenameNefModule } from './RenameNefModule.jsx';
 export { ReviewModule } from './ReviewModule.jsx';
 export { DatabaseManagement } from './DatabaseManagement.jsx';
 export { StartupStatus } from './StartupStatus.jsx';

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -27,6 +27,7 @@ import { RefineFacesModule } from '../../components/RefineFacesModule.jsx';
 import { PlayerCountModule } from '../../components/PlayerCountModule.jsx';
 import { CullingModule } from '../../components/CullingModule.jsx';
 import { ImportModule } from '../../components/ImportModule.jsx';
+import { RenameNefModule } from '../../components/RenameNefModule.jsx';
 
 
 // Storage key for layout persistence
@@ -180,7 +181,8 @@ const MODULE_COMPONENTS = {
   'preferences': PreferencesModule,
   'player-count': PlayerCountModule,
   'culling': CullingModule,
-  'import': ImportModule
+  'import': ImportModule,
+  'rename-nef': RenameNefModule
 };
 
 // Module titles
@@ -197,7 +199,8 @@ const MODULE_TITLES = {
   'preferences': 'Preferences',
   'player-count': 'Räkna spelare',
   'culling': 'Gallra spelare',
-  'import': 'Importera'
+  'import': 'Importera',
+  'rename-nef': 'Byt namn'
 };
 
 // Module-specific default layout ratios
@@ -257,6 +260,11 @@ const MODULE_LAYOUT = {
   },
   'import': {
     widthRatio: 0.40,     // compact form
+    heightRatio: 0.70,    // Primary row
+    row: 1
+  },
+  'rename-nef': {
+    widthRatio: 0.50,     // preview table
     heightRatio: 0.70,    // Primary row
     row: 1
   }
@@ -481,7 +489,8 @@ export function FlexLayoutWorkspace() {
     'theme-editor',
     'player-count',
     'culling',
-    'import'
+    'import',
+    'rename-nef'
   ]);
 
   // Open a module tab
@@ -1150,6 +1159,9 @@ export function FlexLayoutWorkspace() {
           break;
         case 'open-import':
           openModule('import');
+          break;
+        case 'open-rename-nef':
+          openModule('rename-nef');
           break;
         case 'open-database-management':
           openModule('database-management');


### PR DESCRIPTION
## Summary
GUI for the `rename_nef` CLI: rename NEFs from EXIF `CreateDate` to `YYMMDD_HHMMSS.NEF`, with a preview (dry-run) and confirm. Backs a new **Byt namn** module. Next workflow step after import.

### Backend
- Reuses `rename_nef.get_exif_data` + `compute_renames` (batched exiftool read; `-NN` duplicate-timestamp disambiguation).
- `preview` returns the mapping plus `no_date` / `already_named` buckets; `execute` runs a structured two-pass that **carries `.xmp` sidecars** and, unlike the CLI, **restores the original instead of deleting it** when a target name is taken (the CLI `tmp.unlink()` was a latent data-loss bug).
- Guard: only well-formed `YYMMDD_HHMMSS` timestamps are eligible, so a blank `CreateDate` can't rename a file to `.NEF`.
- Routes `POST /api/v1/rename-nef/preview`, `POST /api/v1/rename-nef/execute`.

### Frontend
- **Byt namn** module: folder + optional glob → preview table (`DSC… → YYMMDD_HHMMSS.NEF`, with counts) → confirm + result summary. Menu + `Cmd+Shift+B`.

## Testing
- Backend verified end-to-end with exiftool-written test images: correct names, `-0/-1` for duplicate timestamps, `.xmp` sidecar carried, no-date files excluded (no `.NEF` empty-stem), and a target-name collision **skipped with the original restored** (not deleted).
- Frontend builds clean.
- Real-NEF EXIF read remains a manual check; logic validated via exiftool on stand-in images.

Requires `exiftool` (already a project dependency).
