### PR TITLE
Startup landing page with workflow-step buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 ## [Unreleased]
 
 ### Added
+- **Startup landing page**: when the app opens with an empty workspace, a centered view presents the workflow steps in order (Importera · Byt namn · Granska ansikten · Räkna spelare · Gallra spelare) as buttons that open the matching module. Import is enabled only while a camera card is mounted (polled), the rest are always available. The view disappears once a module opens or an image loads.
 - **Räkna spelare** module: counts images per named player from filenames (no face recognition) with median-baseline over/under-representation stats; folder/glob input with extension presets and a filename-date span; live auto-refresh when the watched folder changes (#46).
 - **Gallra spelare** culling workspace: filter by player or a Finder-style glob, file list beside a maximized preview, keystroke culling (`x`/Delete) with auto-advance and `Cmd+Z` undo, backed by an app-managed trash with restore-to-original (#46). Extended to NEF/RAW via the existing NEF→JPG preview pipeline, with debounced conversion on fast stepping (#47).
 - Folder-level file-watching IPC and a folder-path dialog, shared by the new modules.

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ GUI-onboarding av CLI-skript (en PR per steg):
 - [ ] **Backend distance-optimering** - Optimera distansberäkningar för bättre prestanda
 - [ ] **Duplicate cleanup tool** - Verktyg för att hitta och hantera duplicerade ansikten i databasen
 - [ ] Utveckla smidigare stöd för terminal-interaktion med backend (synkat med frontend)
-- [ ] **Landningssida vid uppstart** — visas i arbetsytan när appen startar utan kö/filer (eller när kön töms vid uppstart för att filerna saknas). Knappar för arbetsflödesstegen i ordning som öppnar respektive modul:
+- [x] **Landningssida vid uppstart** (2026-06-29) — overlay-tomtläge i FlexLayout-arbetsytan med arbetsflödesknappar (Importera · Byt namn · Granska ansikten · Räkna spelare · Gallra spelare); Import villkoras av kortvolym (pollas), övriga alltid aktiva; försvinner när en modul öppnas eller en bild laddas. Knappar via `FlexLayoutWorkspace.openModule`. Ursprunglig spec:
   - Steg (ordning): **Importera · Byt namn · Granska ansikten** (File Queue/Review) **· Räkna spelare · Gallra spelare**.
   - **Aktiv/nedtonad:** Import-knappen aktiv endast när en kortvolym syns (`GET /api/v1/import/volumes` ≠ tom), annars nedtonad/inaktiv. Övriga steg nedtonas om en förutsättning saknas, annars aktiva. (Polla/uppdatera kortstatus så Import tänds när ett kort sätts i.)
   - **Single-instance/fokus:** de flesta vyer är singletons (`SINGLETON_MODULES`) — en knapp ska *fokusera* befintlig instans om den är öppen, annars öppna en ny. `FlexLayoutWorkspace.openModule` gör redan detta; återanvänd den + `handleMenuCommand`-kommandona (`open-import`, `open-rename-nef`, `open-file-queue`/`open-review-module`, `open-player-count`, `open-culling`).

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -103,6 +103,13 @@ Workspace är ett modulärt gränssnitt byggt med FlexLayout. Paneler kan dockas
 
 ## Arbetsflöde
 
+> **Startsida:** När appen startar utan filer i kön visas en startsida i
+> arbetsytan med knappar för arbetsflödesstegen i ordning (**Importera · Byt
+> namn · Granska ansikten · Räkna spelare · Gallra spelare**). Varje knapp
+> öppnar (eller fokuserar) respektive modul. **Importera** är aktiv bara när ett
+> minneskort sitter i (uppdateras automatiskt) — övriga är alltid valbara.
+> Startsidan försvinner så fort du öppnar en modul eller laddar en bild.
+
 ### 0. Importera från minneskort (valfritt)
 
 1. Öppna **Importera** (`Cmd+Shift+I`). Modulen listar isatta minneskort med antal NEF.

--- a/frontend/src/renderer/components/StartupLanding.css
+++ b/frontend/src/renderer/components/StartupLanding.css
@@ -1,0 +1,58 @@
+/* StartupLanding - empty-workspace landing page.
+   Theme-conformant: existing variables only, no new keys, no hardcoded colors. */
+
+.startup-landing {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xl);
+  background: var(--bg-primary);
+  font-family: var(--font-sans);
+}
+
+.startup-landing-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+  max-width: 520px;
+  width: 100%;
+  padding: var(--space-2xl);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  text-align: center;
+}
+
+.startup-landing-title {
+  margin: 0;
+  font-size: var(--font-2xl);
+  color: var(--text-primary);
+}
+
+.startup-landing-subtitle {
+  margin: 0 0 var(--space-lg);
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.startup-landing-steps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  width: 100%;
+}
+
+/* Extends the shared .btn-action; only layout tweaks here. */
+.startup-landing-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  font-size: var(--font-lg);
+}

--- a/frontend/src/renderer/components/StartupLanding.jsx
+++ b/frontend/src/renderer/components/StartupLanding.jsx
@@ -1,0 +1,81 @@
+/**
+ * StartupLanding - Empty-workspace landing page.
+ *
+ * Shown by FlexLayoutWorkspace when the app starts with no queue/files. Presents
+ * the workflow steps in order as buttons that open the matching module. The
+ * Import step is enabled only while a camera card volume is mounted; the others
+ * are always enabled (each module handles its own file selection / empty state).
+ * The view is dismissed by the workspace once a module opens or an image loads.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useBackend } from '../context/BackendContext.jsx';
+import { Icon } from './Icon.jsx';
+import './StartupLanding.css';
+
+// Poll interval for card detection so Import lights up when a card is inserted.
+const VOLUME_POLL_MS = 4000;
+
+// Workflow steps in order. `requiresCard` gates Import on a mounted card volume;
+// the rest are always enabled. `moduleId` strings match MODULE_COMPONENTS.
+const STEPS = [
+  {
+    moduleId: 'import',
+    label: 'Importera',
+    icon: 'folder-plus',
+    requiresCard: true,
+    disabledHint: 'Sätt i ett minneskort för att importera',
+  },
+  { moduleId: 'rename-nef', label: 'Byt namn', icon: 'file' },
+  { moduleId: 'review-module', label: 'Granska ansikten', icon: 'user' },
+  { moduleId: 'player-count', label: 'Räkna spelare', icon: 'layers' },
+  { moduleId: 'culling', label: 'Gallra spelare', icon: 'check-circle' },
+];
+
+export function StartupLanding({ onOpenModule }) {
+  const { api } = useBackend();
+  const [cardPresent, setCardPresent] = useState(false);
+
+  const checkVolumes = useCallback(async () => {
+    try {
+      const data = await api.get('/api/v1/import/volumes');
+      setCardPresent((data.volumes || []).length > 0);
+    } catch {
+      // Backend may not be ready yet; treat as no card and retry on next poll.
+      setCardPresent(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    checkVolumes();
+    const id = setInterval(checkVolumes, VOLUME_POLL_MS);
+    return () => clearInterval(id);
+  }, [checkVolumes]);
+
+  return (
+    <div className="startup-landing" role="region" aria-label="Kom igång">
+      <div className="startup-landing-card">
+        <h1 className="startup-landing-title">Kom igång</h1>
+        <p className="startup-landing-subtitle">Välj ett steg i arbetsflödet.</p>
+        <div className="startup-landing-steps">
+          {STEPS.map((step) => {
+            const disabled = step.requiresCard && !cardPresent;
+            return (
+              <button
+                key={step.moduleId}
+                type="button"
+                className="btn-action startup-landing-step"
+                disabled={disabled}
+                title={disabled ? step.disabledHint : undefined}
+                onClick={() => onOpenModule(step.moduleId)}
+              >
+                <Icon name={step.icon} size={20} />
+                <span>{step.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -1209,11 +1209,15 @@ export function FlexLayoutWorkspace() {
 
     window.ansiktenAPI.on('menu-command', handleMenuCommand);
 
-    // Loading an image (initial file or queue auto-load) dismisses the landing.
-    const unsubscribeLoadImage = moduleAPI.on('load-image', () => setShowLanding(false));
+    // A loaded image dismisses the landing. Listen on the past-tense
+    // 'image-loaded' (emitted by ImageViewer after a load), NOT the imperative
+    // 'load-image' command: FileQueue uses hasListeners('load-image') to detect
+    // when ImageViewer has mounted, and a permanent listener here would defeat
+    // that guard and reintroduce a lost-event race on first queue load.
+    const unsubscribeImageLoaded = moduleAPI.on('image-loaded', () => setShowLanding(false));
 
     return () => {
-      unsubscribeLoadImage();
+      unsubscribeImageLoaded();
     };
   }, [ready, loadLayout, addTabset, removeEmptyTabset, openModule, moduleAPI, moveToNewTabset]);
 

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -28,6 +28,7 @@ import { PlayerCountModule } from '../../components/PlayerCountModule.jsx';
 import { CullingModule } from '../../components/CullingModule.jsx';
 import { ImportModule } from '../../components/ImportModule.jsx';
 import { RenameNefModule } from '../../components/RenameNefModule.jsx';
+import { StartupLanding } from '../../components/StartupLanding.jsx';
 
 
 // Storage key for layout persistence
@@ -343,6 +344,9 @@ export function FlexLayoutWorkspace() {
   const [model, setModel] = useState(null);
   const [ready, setReady] = useState(false);
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
+  // Startup landing page: shown on an empty workspace, dismissed once a module
+  // is opened or an image is loaded.
+  const [showLanding, setShowLanding] = useState(true);
   const moduleAPI = useModuleAPI();
 
   // Initialize model
@@ -504,6 +508,9 @@ export function FlexLayoutWorkspace() {
       debugError('FlexLayout', `Module not found: ${moduleId}`);
       return;
     }
+
+    // Opening any module dismisses the startup landing page.
+    setShowLanding(false);
 
     // Check if module is a singleton and already exists
     const isSingleton = SINGLETON_MODULES.has(moduleId);
@@ -1202,8 +1209,11 @@ export function FlexLayoutWorkspace() {
 
     window.ansiktenAPI.on('menu-command', handleMenuCommand);
 
+    // Loading an image (initial file or queue auto-load) dismisses the landing.
+    const unsubscribeLoadImage = moduleAPI.on('load-image', () => setShowLanding(false));
+
     return () => {
-      // Cleanup if needed
+      unsubscribeLoadImage();
     };
   }, [ready, loadLayout, addTabset, removeEmptyTabset, openModule, moduleAPI, moveToNewTabset]);
 
@@ -1258,6 +1268,7 @@ export function FlexLayoutWorkspace() {
         onModelChange={handleModelChange}
         onAction={handleAction}
       />
+      {showLanding && <StartupLanding onOpenModule={openModule} />}
       {showShortcutsHelp && (
         <ShortcutsHelpOverlay
           onClose={() => setShowShortcutsHelp(false)}

--- a/frontend/tests/StartupLanding.test.jsx
+++ b/frontend/tests/StartupLanding.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Mock the backend context so we control the /import/volumes response.
+const mockGet = vi.fn();
+vi.mock('../src/renderer/context/BackendContext.jsx', () => ({
+  useBackend: () => ({ api: { get: mockGet } }),
+}));
+
+import { StartupLanding } from '../src/renderer/components/StartupLanding.jsx';
+
+describe('StartupLanding', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('renders all five workflow steps in order', async () => {
+    mockGet.mockResolvedValue({ volumes: [] });
+    render(<StartupLanding onOpenModule={() => {}} />);
+
+    const buttons = await screen.findAllByRole('button');
+    expect(buttons.map((b) => b.textContent)).toEqual([
+      'Importera',
+      'Byt namn',
+      'Granska ansikten',
+      'Räkna spelare',
+      'Gallra spelare',
+    ]);
+  });
+
+  it('disables Import when no card volume is present', async () => {
+    mockGet.mockResolvedValue({ volumes: [] });
+    render(<StartupLanding onOpenModule={() => {}} />);
+
+    const importBtn = screen.getByRole('button', { name: /Importera/ });
+    await waitFor(() => expect(importBtn.disabled).toBe(true));
+  });
+
+  it('enables Import when a card volume is present', async () => {
+    mockGet.mockResolvedValue({ volumes: [{ mount: '/Volumes/EOS_DIGITAL' }] });
+    render(<StartupLanding onOpenModule={() => {}} />);
+
+    const importBtn = screen.getByRole('button', { name: /Importera/ });
+    await waitFor(() => expect(importBtn.disabled).toBe(false));
+  });
+
+  it('calls onOpenModule with the step id when a step is clicked', async () => {
+    mockGet.mockResolvedValue({ volumes: [] });
+    const onOpenModule = vi.fn();
+    render(<StartupLanding onOpenModule={onOpenModule} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Granska ansikten/ }));
+    expect(onOpenModule).toHaveBeenCalledWith('review-module');
+  });
+
+  it('does not let a disabled Import button fire onOpenModule', async () => {
+    mockGet.mockResolvedValue({ volumes: [] });
+    const onOpenModule = vi.fn();
+    render(<StartupLanding onOpenModule={onOpenModule} />);
+
+    const importBtn = screen.getByRole('button', { name: /Importera/ });
+    await waitFor(() => expect(importBtn.disabled).toBe(true));
+    fireEvent.click(importBtn);
+    expect(onOpenModule).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Vad

När appen startar med tom arbetsyta (ingen kö/filer) visas en startsida i FlexLayout-arbetsytan med arbetsflödesstegen i ordning som knappar:

**Importera · Byt namn · Granska ansikten · Räkna spelare · Gallra spelare**

Varje knapp öppnar (eller fokuserar, för singleton-moduler) respektive modul via `FlexLayoutWorkspace.openModule`. Startsidan försvinner så fort en modul öppnas eller en bild laddas (`load-image`).

## Detaljer

- **Import-knappen** är aktiv endast när en kortvolym syns. Komponenten pollar `GET /api/v1/import/volumes` var ~4 s så knappen tänds när ett kort sätts i; annars nedtonad med hint.
- **Övriga steg** är alltid aktiva — modulerna hanterar själva filval/tomt läge. STEP-configen har en `requiresCard`-krok så per-steg-gating kan utökas senare.
- Renderas som overlay-tomtläge ovanpå `<Layout>` (samma mönster som `ShortcutsHelpOverlay`), inte som en FlexLayout-modul.
- **Tema:** enbart befintliga temanycklar och `.btn-action`, inga nya CSS-nycklar, inga hårdkodade färger.

## Test

- `npm run build:workspace` — passerar.
- `npm test` — 18/18 gröna, inkl. nytt `StartupLanding.test.jsx` (rendering, ordning, Import enabled/disabled vid kort, klick → rätt modul-id). Repots första React-komponenttest.

Stänger roadmap-steget "Landningssida vid uppstart" (TODO.md › Mellan sikt).