### PR TITLE
Filterrad: tematiska knappar/checkbox + auto-apply (Gallra/Räkna spelare)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 - **Byt namn** module: rename NEFs from EXIF `CreateDate` to `YYMMDD_HHMMSS.NEF` (rename_nef GUI), with a preview (dry-run) and confirm. Carries `.xmp` sidecars, disambiguates identical timestamps (`-NN`), skips files without a `CreateDate`, and never overwrites an existing target (restores the original on collision).
 
 ### Changed
+- Räkna spelare / Gallra spelare filter controls: the primary "Räkna"/"Visa" buttons now use the themed button style (previously rendered as unstyled native buttons), and checkboxes are restyled to match the theme. Changing the player/filetype dropdown, or toggling "Inkl. undermappar" / "Per match", now re-runs immediately — no need to click the button.
 - Documentation: established [CLAUDE.md](CLAUDE.md) as the canonical agent-instructions file; [AGENTS.md](AGENTS.md) and `.github/copilot-instructions.md` now point to it.
 
 ## [1.3.0] - 2026-06-27

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,14 @@ GUI-onboarding av CLI-skript (en PR per steg):
   - **Var:** rendera som tomt-läge i FlexLayout-arbetsytan; försvinner när en modul öppnas eller filer laddas. Se befintlig uppstarts-/tomt-logik (StartupStatus, FlexLayoutWorkspace, ev. `get-initial-file`).
   - **Återanvänd:** modulregistret (`MODULE_COMPONENTS`/`MODULE_TITLES`) för steglistan, import-volym-endpointen för aktiv/nedtonad, ikon/knapp-stilarna från befintliga moduler.
   - Egen PR.
+- [ ] **Räkna spelare GUI: full paritet med CLI (`rakna_spelare.py`)** — GUI:t saknar funktionalitet som CLI-skriptet har; **allt CLI gör ska in i GUI:t**. Verifierat mot koden (backend `player_count_service`/route stödjer redan det mesta; frontend exponerar inte):
+  - **Saknade UI-kontroller** (backend stödjer parametern, frontend skickar den aldrig → default): `gap_minutes` (matchdelningens känslighet, default 30), `baseline` (median/mean), `min_images` (default 3), samt per-request `tranare`/`publik` (visa/redigera tränar-/publiklistorna).
+  - **Saknas i hela stacken:** `--add-tranare`/`--add-publik` (append-semantik) — `_exclusion_sets` gör bara replace; route-modellen saknar fälten.
+  - **Per-match ofullständigt:** "Per match" finns och backend returnerar full per-match-statistik, men GUI:t renderar inte per-match exkluderade hinkar (`m.excluded`) och saknar per-match info-rad (baseline/duration/Δ).
+  - **Visualisering saknas:** temporal "spark" (per-spelare-tidslinje; `timestamps[]` returneras men används inte), match-gräns-markeringar, `ΔN` (absolut avvikelse; bara `Δ%` visas), och fördelnings-baren är `count/maxCount` i GUI men `count/baseline` i CLI.
+  - Ej tillämpligt (CLI-only): `--no-color`/`--color`/`--ascii`/`--bar-width`.
+  - GUI är redan rikare på input (mappar, extension-preset, recursive, datumspann) — inte en lucka.
+  - Egen PR (separat från culling-arbetet).
 - [ ] **Arbetsflödes-layoutpresets** — spara flerfönsterkonfigurationer per uppgift (t.ex. NEF-culling = fillista vänster + maximal preview höger). De flesta vyer är single-instance: öppna inte flera, skifta fokus till befintlig.
 - [ ] **Positions-/progressindikator i culling** — visa var i listan användaren står (fil X/N; granskade gröna, resten grå) i fillistan eller filterraden.
 - [ ] **Omfattande docs-uppdatering** — TODO.md/övriga docs är inaktuella; genomgång + uppdatering (stort jobb, egen PR).

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -55,6 +55,10 @@ export function CullingModule({ node }) {
 
   // Latest filter params for auto-refresh; undo stack of trashed ids.
   const lastQueryRef = useRef(null);
+  // Monotonic id so out-of-order list responses (e.g. switching players fast on
+  // a large folder) can't clobber a newer result — critical here because the
+  // list drives which files `x`/Delete trashes.
+  const reqSeqRef = useRef(0);
   const undoStackRef = useRef([]);
   const watchedDirsRef = useRef(new Set());
   const debounceRef = useRef(null);
@@ -106,9 +110,11 @@ export function CullingModule({ node }) {
   // ----- listing ------------------------------------------------------
   const loadList = useCallback(
     async (query, { keepIndex = false } = {}) => {
+      const seq = ++reqSeqRef.current;
       setIsLoading(true);
       try {
         const data = await api.post('/api/v1/culling/files', query);
+        if (seq !== reqSeqRef.current) return; // a newer request superseded this one
         setFiles(data.files);
         setPlayers(data.players);
         setError(null);
@@ -118,10 +124,14 @@ export function CullingModule({ node }) {
           return 0;
         });
       } catch (err) {
+        if (seq !== reqSeqRef.current) return;
         setError(err.message || String(err));
       } finally {
-        setIsLoading(false);
-        setHasRun(true);
+        // Leave isLoading true if a newer request is still in flight (it will clear it).
+        if (seq === reqSeqRef.current) {
+          setIsLoading(false);
+          setHasRun(true);
+        }
       }
     },
     [api]

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -63,8 +63,10 @@ export function CullingModule({ node }) {
   // The editable glob is a Finder-style basename filter (name_glob) over the
   // resolved files, NOT an independent filesystem glob. The scan source is
   // roots (+ any path-globs carried from the stats module).
+  // `overrides` lets callers run with a just-changed value before the matching
+  // setState has flushed (e.g. auto-apply on a dropdown change).
   const buildQuery = useCallback(
-    () => ({
+    (overrides = {}) => ({
       roots,
       globs: carriedGlobs,
       extension_preset: preset,
@@ -75,6 +77,7 @@ export function CullingModule({ node }) {
       // names can't conflate players; name_glob is the extra editable refinement.
       player: player || null,
       name_glob: glob.trim() || null,
+      ...overrides,
     }),
     [roots, carriedGlobs, preset, recursive, dateFrom, dateTo, player, glob]
   );
@@ -124,8 +127,8 @@ export function CullingModule({ node }) {
     [api]
   );
 
-  const runFilter = useCallback(() => {
-    const query = buildQuery();
+  const runFilter = useCallback((overrides = {}) => {
+    const query = buildQuery(overrides);
     lastQueryRef.current = query;
     loadList(query);
     updateWatches(watchDirs());
@@ -406,7 +409,12 @@ export function CullingModule({ node }) {
         <select
           className="form-select"
           value={preset}
-          onChange={(e) => setPreset(e.target.value)}
+          onChange={(e) => {
+            const v = e.target.value;
+            setPreset(v);
+            // Auto-apply once a scope exists (a query has run).
+            if (lastQueryRef.current) runFilter({ extension_preset: v });
+          }}
           title="Filtyp"
         >
           <option value="jpg">jpg / jpeg</option>
@@ -416,7 +424,15 @@ export function CullingModule({ node }) {
         <select
           className="form-select"
           value={player}
-          onChange={(e) => selectPlayer(e.target.value)}
+          onChange={(e) => {
+            const name = e.target.value;
+            selectPlayer(name);
+            // Picking a player applies immediately — no need to press Visa.
+            if (lastQueryRef.current) {
+              const g = name ? `*${name}*` : '';
+              runFilter({ player: name || null, name_glob: g || null });
+            }
+          }}
           title="Spelare"
         >
           <option value="">Alla spelare</option>
@@ -432,12 +448,12 @@ export function CullingModule({ node }) {
           onChange={(e) => { setGlob(e.target.value); setPlayer(''); }}
           onKeyDown={(e) => { if (e.key === 'Enter') runFilter(); }}
         />
-        <button className="btn-primary" onClick={runFilter} disabled={!canFilter || isLoading}>
+        <button className="btn-action" onClick={() => runFilter()} disabled={!canFilter || isLoading}>
           {isLoading ? '…' : 'Visa'}
         </button>
         <span className="culling-spacer" />
         <button
-          className={showTrash ? 'btn-primary' : 'btn-secondary'}
+          className={showTrash ? 'btn-action' : 'btn-secondary'}
           onClick={() => (showTrash ? setShowTrash(false) : openTrash())}
         >
           Papperskorg

--- a/frontend/src/renderer/components/InputBar.jsx
+++ b/frontend/src/renderer/components/InputBar.jsx
@@ -33,10 +33,22 @@ export function InputBar({
   value,
   onChange,
   onSubmit,
+  onAutoApply,
   presets = DEFAULT_PRESETS,
   busy = false,
   submitLabel = 'Räkna',
 }) {
+  // Select/checkbox changes apply immediately (no need to press the submit
+  // button); the parent decides whether anything has run yet. Free-text fields
+  // (glob, dates) still require Enter / the button.
+  const patchAndApply = useCallback(
+    (partial) => {
+      const next = { ...value, ...partial };
+      onChange(next);
+      onAutoApply?.(next);
+    },
+    [value, onChange, onAutoApply]
+  );
   const patch = useCallback(
     (partial) => onChange({ ...value, ...partial }),
     [value, onChange]
@@ -91,7 +103,7 @@ export function InputBar({
         <select
           className="form-select"
           value={value.preset}
-          onChange={(e) => patch({ preset: e.target.value })}
+          onChange={(e) => patchAndApply({ preset: e.target.value })}
           disabled={busy}
           title="Filtyper (skiftlägesokänsligt)"
         >
@@ -102,7 +114,7 @@ export function InputBar({
           ))}
         </select>
 
-        <button className="btn-primary" onClick={submit} disabled={!canSubmit}>
+        <button className="btn-action" onClick={submit} disabled={!canSubmit}>
           {busy ? '…' : submitLabel}
         </button>
       </div>
@@ -132,7 +144,7 @@ export function InputBar({
           <input
             type="checkbox"
             checked={value.recursive}
-            onChange={(e) => patch({ recursive: e.target.checked })}
+            onChange={(e) => patchAndApply({ recursive: e.target.checked })}
             disabled={busy}
           />
           Inkl. undermappar

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -29,6 +29,9 @@ export function PlayerCountModule() {
 
   // Params of the last submitted query, so auto-refresh re-runs the same thing.
   const lastParamsRef = useRef(null);
+  // Monotonic id so a slower older request can't overwrite a newer result
+  // (e.g. toggling Per match / filters quickly on a large folder).
+  const reqSeqRef = useRef(0);
   const watchedDirsRef = useRef(new Set());
   const debounceRef = useRef(null);
 
@@ -47,18 +50,23 @@ export function PlayerCountModule() {
 
   const runCount = useCallback(
     async (params, { silent = false } = {}) => {
+      const seq = ++reqSeqRef.current;
       if (silent) setIsRefreshing(true);
       else setIsLoading(true);
       try {
         const data = await api.post('/api/v1/players/count', params);
+        if (seq !== reqSeqRef.current) return; // superseded by a newer request
         setResult(data);
         setError(null);
       } catch (err) {
+        if (seq !== reqSeqRef.current) return;
         setError(err.message || String(err));
       } finally {
-        setIsLoading(false);
-        setIsRefreshing(false);
-        setHasRun(true);
+        if (seq === reqSeqRef.current) {
+          setIsLoading(false);
+          setIsRefreshing(false);
+          setHasRun(true);
+        }
       }
     },
     [api]

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -91,12 +91,30 @@ export function PlayerCountModule() {
     watchedDirsRef.current = desired;
   }, []);
 
-  const handleSubmit = useCallback(() => {
-    const params = buildParams(input, perMatch);
-    lastParamsRef.current = params;
-    runCount(params);
-    updateWatches(watchDirsFor(input));
-  }, [input, perMatch, buildParams, runCount, updateWatches, watchDirsFor]);
+  const submitWith = useCallback(
+    (inp, includePerMatch) => {
+      const params = buildParams(inp, includePerMatch);
+      lastParamsRef.current = params;
+      runCount(params);
+      updateWatches(watchDirsFor(inp));
+    },
+    [buildParams, runCount, updateWatches, watchDirsFor]
+  );
+
+  const handleSubmit = useCallback(
+    () => submitWith(input, perMatch),
+    [submitWith, input, perMatch]
+  );
+
+  // Select/checkbox changes from the InputBar apply immediately, but only once a
+  // query has run (otherwise there's nothing to recompute yet).
+  const handleAutoApply = useCallback(
+    (nextInput) => {
+      setInput(nextInput);
+      if (lastParamsRef.current) submitWith(nextInput, perMatch);
+    },
+    [submitWith, perMatch]
+  );
 
   // Open the culling workspace filtered to a player (from the stats table).
   const openCullForPlayer = useCallback(
@@ -148,7 +166,11 @@ export function PlayerCountModule() {
             <input
               type="checkbox"
               checked={perMatch}
-              onChange={(e) => setPerMatch(e.target.checked)}
+              onChange={(e) => {
+                const v = e.target.checked;
+                setPerMatch(v);
+                if (lastParamsRef.current) submitWith(input, v);
+              }}
             />
             Per match
           </label>
@@ -156,7 +178,13 @@ export function PlayerCountModule() {
         </div>
       </div>
 
-      <InputBar value={input} onChange={setInput} onSubmit={handleSubmit} busy={isLoading} />
+      <InputBar
+        value={input}
+        onChange={setInput}
+        onSubmit={handleSubmit}
+        onAutoApply={handleAutoApply}
+        busy={isLoading}
+      />
 
       <div className="module-body player-count-body">
         {error && <div className="status-message error">Fel: {error}</div>}

--- a/frontend/src/renderer/theme.css
+++ b/frontend/src/renderer/theme.css
@@ -548,10 +548,35 @@
 }
 
 .form-checkbox input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
   width: 16px;
   height: 16px;
   margin: 0;
-  accent-color: var(--accent-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.form-checkbox input[type="checkbox"]:hover {
+  border-color: var(--accent-primary);
+}
+
+.form-checkbox input[type="checkbox"]:checked {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
+.form-checkbox input[type="checkbox"]:checked::after {
+  content: '✓';
+  color: var(--text-on-accent);
+  font-size: 11px;
+  line-height: 1;
 }
 
 /* Slider (range) container */


### PR DESCRIPTION
## Vad

Polering av filterraden i **Gallra spelare** (culling) och **Räkna spelare** (player-count):

- **Styling:** "Visa" och "Räkna" använde klassen `btn-primary` som **inte finns** i `theme.css` → renderades som råa nativeknappar. Bytt till temats `btn-action`. `.form-checkbox` är omstylad till en temad kontroll (tidigare native accent-color-ruta).
- **Auto-apply:** byte i spelar-/filtyp-dropdownen, eller toggling av "Inkl. undermappar" / "Per match", kör om frågan direkt (när en fråga redan körts). Fritext (glob/datum) kräver fortfarande Enter/knapp.

Tema-konformt: endast befintliga CSS-variabler, inga nya nycklar.

Innehåller även en dokumentationscommit: **TODO.md** loggar att Räkna spelare-GUI:t saknar funktionalitet jämfört med CLI-skriptet (`rakna_spelare.py`) — gap-minutes/baseline/min-images-kontroller, tränar/publik-redigering + `--add-*`, per-match exkluderade hinkar, temporal spark, ΔN m.m. Egen PR senare.

## Test
- `npm run build:workspace` ✓
- `npm test` ✓ 18/18

Del av planen "Gallra/Räkna spelare — workspace-förbättringar" (PR 1 av 4).