### PR TITLE
Gallra-layout: solo-vy + live spelarräkning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 - **Importera** module: detect the mounted camera card, transfer its NEFs (+ `.xmp` sidecars) to a destination folder with live progress (move or copy, selectable), then eject the card. Skips files already present; ejects only after a zero-error transfer. macOS (`diskutil`) (#48-followup).
 - **Byt namn** module: rename NEFs from EXIF `CreateDate` to `YYMMDD_HHMMSS.NEF` (rename_nef GUI), with a preview (dry-run) and confirm. Carries `.xmp` sidecars, disambiguates identical timestamps (`-NN`), skips files without a `CreateDate`, and never overwrites an existing target (restores the original on collision).
 
+### Added
+- **Gallra spelare** now shows a live per-player count column on the left for the current scope (calls the player-count endpoint), updating immediately as you cull or restore files — so you can see each player's balance shift while you work.
+
 ### Changed
+- Workflow steps launched from the startup landing page now open in a layout suited to the step: the self-contained modules (Importera · Byt namn · Räkna spelare · Gallra spelare) fill the workspace instead of docking beside the empty Review panel, and "Granska ansikten" opens the review layout.
 - Räkna spelare / Gallra spelare filter controls: the primary "Räkna"/"Visa" buttons now use the themed button style (previously rendered as unstyled native buttons), and checkboxes are restyled to match the theme. Changing the player/filetype dropdown, or toggling "Inkl. undermappar" / "Per match", now re-runs immediately — no need to click the button.
 - Documentation: established [CLAUDE.md](CLAUDE.md) as the canonical agent-instructions file; [AGENTS.md](AGENTS.md) and `.github/copilot-instructions.md` now point to it.
+
+### Fixed
+- Gallra spelare CSS referenced undefined `--border-color` / `--accent` variables, so borders fell back to nothing and the active file row rendered a non-theme blue; it now uses the theme variables (the active row uses the theme accent in both light and dark).
 
 ## [1.3.0] - 2026-06-27
 

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -170,9 +170,11 @@ antal.
    (`jpg`/`nef`/`raw`) i balken — `nef`/`raw` används för allmän gallring på
    råfiler innan namn satts (förhandsvisas via NEF→JPG-konvertering;
    spelar-menyn är då tom och du filtrerar på mapp/datum/glob).
-3. Bläddra i fillistan till vänster (`↑`/`↓`); bilden visas maximerad till höger.
-   Tryck `x` (eller `Delete`) för att flytta bilden till papperskorgen och gå
-   vidare. `Cmd+Z` ångrar.
+3. Bläddra i fillistan i mitten (`↑`/`↓`); bilden visas maximerad till höger.
+   Längst till vänster visas en **levande spelarräkning** för det aktuella
+   urvalet som uppdateras direkt när du gallrar — så du ser hur varje spelares
+   antal förändras. Tryck `x` (eller `Delete`) för att flytta bilden till
+   papperskorgen och gå vidare. `Cmd+Z` ångrar.
 4. Papperskorgen (knappen **Papperskorg**) listar gallrade bilder och återställer
    dem till ursprungsplatsen, eller tömmer permanent.
 

--- a/frontend/src/renderer/components/CullingModule.css
+++ b/frontend/src/renderer/components/CullingModule.css
@@ -10,7 +10,7 @@
   gap: 8px;
   padding: 8px 12px;
   background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-subtle);
   flex-wrap: wrap;
 }
 
@@ -28,7 +28,7 @@
   flex-wrap: wrap;
   gap: 6px;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .culling-chip {
@@ -38,7 +38,7 @@
   padding: 2px 6px 2px 8px;
   border-radius: 12px;
   background: var(--bg-tertiary, var(--bg-primary));
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-subtle);
   font-size: 0.8em;
 }
 
@@ -58,11 +58,91 @@
   min-height: 0;
 }
 
+/* Live per-player count column (left of the list+preview area). */
+.culling-stats {
+  flex: 0 0 190px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+}
+
+.culling-stats-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 6px 10px;
+  font-size: 0.85em;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.culling-stats-baseline {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.culling-stats-empty {
+  padding: 8px 10px;
+  color: var(--text-secondary);
+}
+
+.culling-stats-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.culling-stat {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 3px 10px;
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+  border-left: 3px solid transparent;
+}
+
+.culling-stat-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.culling-stat-count {
+  color: var(--text-secondary);
+}
+
+/* Deviation from baseline (matches the player-count level thresholds). */
+.culling-stat.delta-high { border-left-color: var(--color-error); }
+.culling-stat.delta-warn { border-left-color: var(--color-warning); }
+.culling-stat.delta-ok { border-left-color: var(--color-success); }
+
+.culling-stat.active {
+  background: var(--bg-active);
+  font-weight: 600;
+}
+
+.culling-stat.active .culling-stat-count {
+  color: var(--text-primary);
+}
+
+/* Wraps the list + divider + preview so the divider drag measures this area
+   (excluding the fixed stats column). */
+.culling-main {
+  flex: 1;
+  display: flex;
+  min-width: 0;
+}
+
 .culling-list {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  border-right: 1px solid var(--border-color);
+  border-right: 1px solid var(--border-subtle);
   overflow: hidden;
 }
 
@@ -70,7 +150,7 @@
   padding: 6px 10px;
   font-size: 0.85em;
   color: var(--text-secondary);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .culling-files {
@@ -96,19 +176,19 @@
 }
 
 .culling-files li.active {
-  background: var(--accent, #3b82f6);
-  color: #fff;
+  background: var(--accent-primary);
+  color: var(--text-on-accent);
 }
 
 .culling-divider {
   width: 5px;
   cursor: col-resize;
-  background: var(--border-color);
+  background: var(--border-subtle);
   flex: 0 0 auto;
 }
 
 .culling-divider:hover {
-  background: var(--accent, #3b82f6);
+  background: var(--accent-primary);
 }
 
 .culling-preview {
@@ -155,7 +235,7 @@
   justify-content: space-between;
   gap: 8px;
   padding: 5px 0;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-subtle);
   font-size: 0.85em;
 }
 

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -80,7 +80,7 @@ export function CullingModule({ node }) {
   const undoStackRef = useRef([]);
   const watchedDirsRef = useRef(new Set());
   const debounceRef = useRef(null);
-  const bodyRef = useRef(null);
+  const statsDebounceRef = useRef(null);
   const mainRef = useRef(null);
 
   // The editable glob is a Finder-style basename filter (name_glob) over the
@@ -173,6 +173,15 @@ export function CullingModule({ node }) {
     [api]
   );
 
+  // Trailing-debounced stats refresh for the mutation paths (cull/restore), so
+  // rapid culling coalesces into one rescan instead of a backend scan per key.
+  const refreshStatsDebounced = useCallback(() => {
+    if (statsDebounceRef.current) clearTimeout(statsDebounceRef.current);
+    statsDebounceRef.current = setTimeout(() => {
+      loadStats(statsScopeFromQuery(lastQueryRef.current));
+    }, REFRESH_DEBOUNCE_MS);
+  }, [loadStats]);
+
   const runFilter = useCallback((overrides = {}) => {
     const query = buildQuery(overrides);
     lastQueryRef.current = query;
@@ -193,6 +202,7 @@ export function CullingModule({ node }) {
     });
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (statsDebounceRef.current) clearTimeout(statsDebounceRef.current);
       if (unsubscribe) unsubscribe();
       for (const dir of watchedDirsRef.current) window.ansiktenAPI.unwatchFolder?.(dir);
       watchedDirsRef.current = new Set();
@@ -282,8 +292,8 @@ export function CullingModule({ node }) {
       const id = res.trashed?.[0]?.id;
       if (id) {
         undoStackRef.current.push(id);
-        // Reflect the removed image in the live counts.
-        loadStats(statsScopeFromQuery(lastQueryRef.current));
+        // Reflect the removed image in the live counts (debounced for fast culling).
+        refreshStatsDebounced();
       } else {
         // 200 with errors[] (permission/lock/race): the file is still on disk, so
         // roll the optimistic removal back by reloading and surface the reason.
@@ -295,7 +305,7 @@ export function CullingModule({ node }) {
       // Re-fetch to recover correct state on failure.
       if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
     }
-  }, [api, currentIndex, files, loadList, loadStats]);
+  }, [api, currentIndex, files, loadList, refreshStatsDebounced]);
 
   const undoTrash = useCallback(async () => {
     // Pop until a still-trashed id restores - ids restored via the trash view
@@ -307,7 +317,7 @@ export function CullingModule({ node }) {
         if (res.restored && res.restored.length > 0) {
           if (lastQueryRef.current) {
             loadList(lastQueryRef.current, { keepIndex: true });
-            loadStats(statsScopeFromQuery(lastQueryRef.current));
+            refreshStatsDebounced();
           }
           return;
         }
@@ -317,7 +327,7 @@ export function CullingModule({ node }) {
         return;
       }
     }
-  }, [api, loadList, loadStats]);
+  }, [api, loadList, refreshStatsDebounced]);
 
   // ----- keyboard ----------------------------------------------------
   useEffect(() => {
@@ -370,7 +380,7 @@ export function CullingModule({ node }) {
           undoStackRef.current = undoStackRef.current.filter((x) => x !== id);
           if (lastQueryRef.current) {
             loadList(lastQueryRef.current, { keepIndex: true });
-            loadStats(statsScopeFromQuery(lastQueryRef.current));
+            refreshStatsDebounced();
           }
         } else {
           // 200 with errors[] (unwritable folder, missing stored file): the item
@@ -381,7 +391,7 @@ export function CullingModule({ node }) {
         setError(err.message || String(err));
       }
     },
-    [api, loadList, loadStats]
+    [api, loadList, refreshStatsDebounced]
   );
 
   const emptyTrash = useCallback(async () => {
@@ -553,7 +563,7 @@ export function CullingModule({ node }) {
           )}
         </div>
       ) : (
-        <div className="culling-body" ref={bodyRef}>
+        <div className="culling-body">
           <CullingStats stats={stats} selected={player} />
           <div className="culling-main" ref={mainRef}>
           <div className="culling-list" style={{ width: `${leftWidthPct}%` }}>

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -22,6 +22,8 @@ const PREVIEW_DEBOUNCE_MS = 150;
 
 // The live stats panel counts every player in the folder, so it uses the
 // scan scope only — not the player/name_glob filter that narrows the file list.
+// min_images: 1 overrides the count endpoint's default of 3 so players culled
+// down to 1-2 images stay visible (the whole point is watching counts shrink).
 function statsScopeFromQuery(q) {
   if (!q) return null;
   return {
@@ -31,6 +33,7 @@ function statsScopeFromQuery(q) {
     recursive: q.recursive,
     date_from: q.date_from,
     date_to: q.date_to,
+    min_images: 1,
   };
 }
 

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -20,6 +20,20 @@ const REFRESH_DEBOUNCE_MS = 400;
 // only converts the file the user rests on, not every file passed through.
 const PREVIEW_DEBOUNCE_MS = 150;
 
+// The live stats panel counts every player in the folder, so it uses the
+// scan scope only — not the player/name_glob filter that narrows the file list.
+function statsScopeFromQuery(q) {
+  if (!q) return null;
+  return {
+    roots: q.roots,
+    globs: q.globs,
+    extension_preset: q.extension_preset,
+    recursive: q.recursive,
+    date_from: q.date_from,
+    date_to: q.date_to,
+  };
+}
+
 export function CullingModule({ node }) {
   const { api } = useBackend();
 
@@ -27,6 +41,9 @@ export function CullingModule({ node }) {
   const [glob, setGlob] = useState('');
   const [player, setPlayer] = useState('');
   const [players, setPlayers] = useState([]);
+  // Live per-player counts for the current scope (from /players/count), shown in
+  // the left stats column and refreshed as files are culled.
+  const [stats, setStats] = useState(null);
   const [preset, setPreset] = useState('jpg'); // jpg | nef | raw
   // Scope carried from the stats module (glob-only runs, date span, recursion).
   // The culling bar has no date inputs, so we keep these to honour the count's
@@ -59,10 +76,12 @@ export function CullingModule({ node }) {
   // a large folder) can't clobber a newer result — critical here because the
   // list drives which files `x`/Delete trashes.
   const reqSeqRef = useRef(0);
+  const statsSeqRef = useRef(0);
   const undoStackRef = useRef([]);
   const watchedDirsRef = useRef(new Set());
   const debounceRef = useRef(null);
   const bodyRef = useRef(null);
+  const mainRef = useRef(null);
 
   // The editable glob is a Finder-style basename filter (name_glob) over the
   // resolved files, NOT an independent filesystem glob. The scan source is
@@ -137,12 +156,30 @@ export function CullingModule({ node }) {
     [api]
   );
 
+  // Live per-player counts for the scan scope (no player filter), so the panel
+  // shows the balance across all players. Guarded against out-of-order responses.
+  const loadStats = useCallback(
+    async (scope) => {
+      if (!scope) return;
+      const seq = ++statsSeqRef.current;
+      try {
+        const data = await api.post('/api/v1/players/count', scope);
+        if (seq !== statsSeqRef.current) return;
+        setStats(data);
+      } catch {
+        if (seq === statsSeqRef.current) setStats(null);
+      }
+    },
+    [api]
+  );
+
   const runFilter = useCallback((overrides = {}) => {
     const query = buildQuery(overrides);
     lastQueryRef.current = query;
     loadList(query);
+    loadStats(statsScopeFromQuery(query));
     updateWatches(watchDirs());
-  }, [buildQuery, loadList, updateWatches, watchDirs]);
+  }, [buildQuery, loadList, loadStats, updateWatches, watchDirs]);
 
   // Auto-refresh on folder change.
   useEffect(() => {
@@ -151,6 +188,7 @@ export function CullingModule({ node }) {
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
         loadList(lastQueryRef.current, { keepIndex: true });
+        loadStats(statsScopeFromQuery(lastQueryRef.current));
       }, REFRESH_DEBOUNCE_MS);
     });
     return () => {
@@ -159,7 +197,7 @@ export function CullingModule({ node }) {
       for (const dir of watchedDirsRef.current) window.ansiktenAPI.unwatchFolder?.(dir);
       watchedDirsRef.current = new Set();
     };
-  }, [loadList]);
+  }, [loadList, loadStats]);
 
   // ----- filter bar actions ------------------------------------------
   const addFolders = useCallback(async () => {
@@ -216,6 +254,7 @@ export function CullingModule({ node }) {
       };
       lastQueryRef.current = query;
       loadList(query);
+      loadStats(statsScopeFromQuery(query));
 
       const dirs = new Set(nextRoots);
       for (const g of nextGlobs) {
@@ -224,7 +263,7 @@ export function CullingModule({ node }) {
       }
       updateWatches(dirs);
     },
-    [loadList, updateWatches]
+    [loadList, loadStats, updateWatches]
   );
 
   // ----- cull loop ----------------------------------------------------
@@ -243,6 +282,8 @@ export function CullingModule({ node }) {
       const id = res.trashed?.[0]?.id;
       if (id) {
         undoStackRef.current.push(id);
+        // Reflect the removed image in the live counts.
+        loadStats(statsScopeFromQuery(lastQueryRef.current));
       } else {
         // 200 with errors[] (permission/lock/race): the file is still on disk, so
         // roll the optimistic removal back by reloading and surface the reason.
@@ -254,7 +295,7 @@ export function CullingModule({ node }) {
       // Re-fetch to recover correct state on failure.
       if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
     }
-  }, [api, currentIndex, files, loadList]);
+  }, [api, currentIndex, files, loadList, loadStats]);
 
   const undoTrash = useCallback(async () => {
     // Pop until a still-trashed id restores - ids restored via the trash view
@@ -264,7 +305,10 @@ export function CullingModule({ node }) {
       try {
         const res = await api.post('/api/v1/culling/restore', { ids: [id] });
         if (res.restored && res.restored.length > 0) {
-          if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+          if (lastQueryRef.current) {
+            loadList(lastQueryRef.current, { keepIndex: true });
+            loadStats(statsScopeFromQuery(lastQueryRef.current));
+          }
           return;
         }
         // id no longer in trash -> fall through and try the next one.
@@ -273,7 +317,7 @@ export function CullingModule({ node }) {
         return;
       }
     }
-  }, [api, loadList]);
+  }, [api, loadList, loadStats]);
 
   // ----- keyboard ----------------------------------------------------
   useEffect(() => {
@@ -324,7 +368,10 @@ export function CullingModule({ node }) {
           setTrashItems((prev) => prev.filter((it) => it.id !== id));
           // Keep the cull-loop undo stack in sync - this id is no longer trashable.
           undoStackRef.current = undoStackRef.current.filter((x) => x !== id);
-          if (lastQueryRef.current) loadList(lastQueryRef.current, { keepIndex: true });
+          if (lastQueryRef.current) {
+            loadList(lastQueryRef.current, { keepIndex: true });
+            loadStats(statsScopeFromQuery(lastQueryRef.current));
+          }
         } else {
           // 200 with errors[] (unwritable folder, missing stored file): the item
           // stays in the manifest, so keep it visible and surface the reason.
@@ -334,7 +381,7 @@ export function CullingModule({ node }) {
         setError(err.message || String(err));
       }
     },
-    [api, loadList]
+    [api, loadList, loadStats]
   );
 
   const emptyTrash = useCallback(async () => {
@@ -350,10 +397,11 @@ export function CullingModule({ node }) {
   // ----- divider drag ------------------------------------------------
   const startDrag = useCallback((e) => {
     e.preventDefault();
-    const body = bodyRef.current;
-    if (!body) return;
+    // Measure against the list+preview area (excludes the fixed stats column).
+    const main = mainRef.current;
+    if (!main) return;
     const onMove = (ev) => {
-      const rect = body.getBoundingClientRect();
+      const rect = main.getBoundingClientRect();
       const pct = ((ev.clientX - rect.left) / rect.width) * 100;
       setLeftWidthPct(Math.min(70, Math.max(15, pct)));
     };
@@ -506,6 +554,8 @@ export function CullingModule({ node }) {
         </div>
       ) : (
         <div className="culling-body" ref={bodyRef}>
+          <CullingStats stats={stats} selected={player} />
+          <div className="culling-main" ref={mainRef}>
           <div className="culling-list" style={{ width: `${leftWidthPct}%` }}>
             <div className="culling-list-header">
               {files.length} bilder{player ? ` · ${player}` : ''}
@@ -541,6 +591,7 @@ export function CullingModule({ node }) {
             ) : previewUrl ? (
               <img className="culling-image" src={previewUrl} alt={current.basename} />
             ) : null}
+          </div>
           </div>
         </div>
       )}
@@ -580,6 +631,43 @@ function globBaseDir(pattern) {
 function basename(p) {
   const parts = p.replace(/\/+$/, '').split('/');
   return parts[parts.length - 1] || p;
+}
+
+/**
+ * Live per-player count for the current scope, shown left of the file list.
+ * `stats` is the /players/count response (or null); `selected` highlights the
+ * player currently filtered in the list.
+ */
+function CullingStats({ stats, selected }) {
+  const players = stats?.players || [];
+  return (
+    <div className="culling-stats">
+      <div className="culling-stats-header">
+        <span>Spelare</span>
+        {stats?.baseline != null && (
+          <span className="culling-stats-baseline" title="Baslinje (median)">
+            ~{Math.round(stats.baseline)}
+          </span>
+        )}
+      </div>
+      {players.length === 0 ? (
+        <div className="culling-stats-empty">—</div>
+      ) : (
+        <ul className="culling-stats-list">
+          {players.map((p) => (
+            <li
+              key={p.name}
+              className={`culling-stat delta-${p.level || 'ok'}${p.name === selected ? ' active' : ''}`}
+              title={`${p.name}: ${p.count}`}
+            >
+              <span className="culling-stat-name">{p.name}</span>
+              <span className="culling-stat-count">{p.count}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
 }
 
 export default CullingModule;

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -6,7 +6,7 @@
 
 import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { Layout, Model, Actions, DockLocation } from 'flexlayout-react';
-import { reviewLayout, getLayoutByName } from './layouts.js';
+import { reviewLayout, getLayoutByName, singleModuleLayout } from './layouts.js';
 import { preferences } from '../preferences.js';
 import { themeManager } from '../../theme-manager.js';
 import { useModuleAPI } from '../../context/ModuleAPIContext.jsx';
@@ -203,6 +203,12 @@ const MODULE_TITLES = {
   'import': 'Importera',
   'rename-nef': 'Byt namn'
 };
+
+// Self-contained workflow modules render their own full UI, so a landing-page
+// click gives them the whole workspace (a single-module layout) rather than
+// docking beside the empty Review panel. Review is not here: it needs the
+// Image Viewer beside it, so its landing button loads the review layout.
+const SOLO_WORKFLOW_MODULES = new Set(['import', 'rename-nef', 'player-count', 'culling']);
 
 // Module-specific default layout ratios
 // widthRatio: proportion of row width (horizontal split)
@@ -728,6 +734,29 @@ export function FlexLayoutWorkspace() {
       debugError('FlexLayout', 'Failed to load layout:', err);
     }
   }, []);
+
+  // Replace the workspace with a single self-contained module filling it. Used
+  // by the landing page for workflow steps (culling, player-count, import,
+  // rename-nef) so they don't dock beside the empty Review panel.
+  const openModuleSolo = useCallback((moduleId) => {
+    setShowLanding(false);
+    try {
+      setModel(Model.fromJson(singleModuleLayout(moduleId, MODULE_TITLES[moduleId])));
+    } catch (err) {
+      debugError('FlexLayout', 'Failed to open module solo:', err);
+    }
+  }, []);
+
+  const openLandingStep = useCallback((moduleId) => {
+    setShowLanding(false);
+    if (moduleId === 'review-module') {
+      loadLayout('review');
+    } else if (SOLO_WORKFLOW_MODULES.has(moduleId)) {
+      openModuleSolo(moduleId);
+    } else {
+      openModule(moduleId);
+    }
+  }, [loadLayout, openModuleSolo, openModule]);
 
   // Helper: Get DockLocation from direction string
   const getDockLocation = useCallback((direction) => {
@@ -1272,7 +1301,7 @@ export function FlexLayoutWorkspace() {
         onModelChange={handleModelChange}
         onAction={handleAction}
       />
-      {showLanding && <StartupLanding onOpenModule={openModule} />}
+      {showLanding && <StartupLanding onOpenModule={openLandingStep} />}
       {showShortcutsHelp && (
         <ShortcutsHelpOverlay
           onClose={() => setShowShortcutsHelp(false)}

--- a/frontend/src/renderer/workspace/flexlayout/layouts.js
+++ b/frontend/src/renderer/workspace/flexlayout/layouts.js
@@ -380,6 +380,51 @@ export const databaseLayout = {
 };
 
 /**
+ * Single-module layout: one full-width tabset holding just the given module.
+ * Used for self-contained workflow modules (culling, player-count, import,
+ * rename-nef) opened from the landing page so they fill the workspace instead
+ * of docking beside the Review panel.
+ * @param {string} moduleId - Module component id
+ * @param {string} [title] - Tab title (defaults to moduleId)
+ * @returns {object} FlexLayout JSON configuration
+ */
+export function singleModuleLayout(moduleId, title) {
+  return {
+    global: {
+      tabEnableClose: true,
+      tabSetEnableMaximize: true,
+      tabSetEnableDrag: true,
+      tabSetEnableDrop: true,
+      tabSetMinWidth: 100,
+      tabSetMinHeight: 100,
+      borderMinSize: 100,
+      splitterSize: 4,
+      enableEdgeDock: true,
+      tabEnableRenderOnDemand: true
+    },
+    layout: {
+      type: 'row',
+      weight: 100,
+      children: [
+        {
+          type: 'tabset',
+          weight: 100,
+          children: [
+            {
+              type: 'tab',
+              name: title || moduleId,
+              component: moduleId,
+              enableRenderOnDemand: false,
+              config: { moduleId }
+            }
+          ]
+        }
+      ]
+    }
+  };
+}
+
+/**
  * Get layout by name
  * @param {string} name - Layout name
  * @returns {object} FlexLayout JSON configuration


### PR DESCRIPTION
## Vad

PR 2 av planen "Gallra/Räkna spelare — workspace-förbättringar".

**A. Solo-layout för arbetsflödessteg (fixar lingerande Review).**
Landningsknapparna använde `openModule`, som dockar modulen i den befintliga review-layouten — så Gallra spelare öppnades med den tomma Review-panelen kvar bredvid. Ny `singleModuleLayout`-factory + routing: självständiga moduler (Importera/Byt namn/Räkna spelare/Gallra spelare) fyller arbetsytan; "Granska ansikten" laddar review-layouten.

**B. Live spelarräkning i Gallra.**
Vänsterkolumnen visar nu en levande per-spelare-räkning för det aktuella urvalet (via `POST /api/v1/players/count`, utan player-filtret), som uppdateras direkt när du gallrar/återställer och vid filändringar. Race-skyddad (request-id), som i PR 1.

**Fix:** culling-CSS:en refererade odefinierade `--border-color`/`--accent` (aktiv rad blev en icke-tema-blå); använder nu temavariabler.

## Test
- `npm run build:workspace` ✓
- `npm test` ✓ 18/18
- Manuellt: öppna Gallra från landningssidan → endast culling (ingen Review); vänsterkolumn visar antal per spelare som sjunker när man gallrar.