### PR TITLE
Rename: keep manually added faces in the new filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 - Documentation: established [CLAUDE.md](CLAUDE.md) as the canonical agent-instructions file; [AGENTS.md](AGENTS.md) and `.github/copilot-instructions.md` now point to it.
 
 ### Fixed
+- Rename now keeps manually added faces in the new filename. Manual faces are persisted with the file's content hash (the batch-confirm path previously stored `hash=None`), and the rename name lookup now takes the union of basename- and hash-matched names instead of consulting the hash index only as a fallback — so a manual face anchored by only one key is no longer dropped when an auto-detected face matches by the other. Applies to both the GUI and the legacy CLI rename.
 - Gallra spelare CSS referenced undefined `--border-color` / `--accent` variables, so borders fell back to nothing and the active file row rendered a non-theme blue; it now uses the theme variables (the active row uses the theme accent in both light and dark).
 
 ## [1.3.0] - 2026-06-27

--- a/RENAME_MANUAL_FACES_PLAN.md
+++ b/RENAME_MANUAL_FACES_PLAN.md
@@ -1,0 +1,97 @@
+# Rename bug — manually added faces dropped from new filename
+
+Status: **fixed** on branch `feature/rename-manual-faces`.
+
+## Context
+
+When a NEF is renamed by the face-based rename pipeline, the new filename included
+auto-detected + confirmed faces but **dropped manually added faces**. Reported example:
+`~/Pictures/nerladdat/260111_080910_Aryan.NEF` — "Aryan" was auto-detected and confirmed,
+"Elis" was added manually, yet the rename produced only `_Aryan`.
+
+CHANGELOG 1.1.0 claims this was already fixed ("Fixed rename pipeline to include manual
+faces"). That merge logic *is* present and correct, but a structural data-model gap
+underneath it could still drop manual faces.
+
+## Root cause
+
+The relevant pipeline is the **face/name-based rename**: `routes/files.py` →
+`services/rename_service.py`. All name assembly happens in `preview_rename` →
+`collect_persons_for_files` (`rename_service.py`), merging three sources: `encodings.pkl`
+(`known_faces`), `attempt_stats.jsonl` (`attempt_log`), and `processed_files.jsonl`.
+
+A **detected** face is double-anchored: in `encodings.pkl` with a real `hash` *and* `file`,
+and in `attempt_stats.jsonl` by content `file_hash`. A **manually added** face was fragilely
+single-anchored, due to two interacting defects:
+
+1. **`hash=None` for manual encodings** — the batch-confirm path the GUI uses
+   (`_confirm_identity_nosave` manual branch, `detection_service.py`) stored `hash=None`.
+   (The single-call async `confirm_identity` *did* compute the hash — the two paths were
+   inconsistent.) A `hash=None` entry is indexed only by basename, never by hash, so it is
+   recoverable only by an exact current-basename match.
+2. **Hash lookup was a fallback, not a union** — `collect_persons_for_files` consulted the
+   hash index only when the basename index was empty (`if not encoding_persons and h:`).
+   Once the detected face was found by basename, the hash branch was skipped, so a
+   hash-only-anchored manual face was silently dropped.
+
+`attempt_stats.jsonl` is the remaining safety net (it carries manual faces by content hash),
+so the bug manifested when that lookup also missed — chiefly when the rename ran **before**
+`mark_review_complete`/the manual confirm had persisted the name (an ordering issue), or on
+stale data written before earlier fixes.
+
+## Diagnostic findings (real data, `~/.local/share/faceid/`)
+
+Inspecting the reported file confirmed all of the above:
+
+- **encodings.pkl**: "Elis Niemi" (`is_manual=True`) and "Aryan Rasheed" now both carry the
+  same content hash `531d80efa0…` and the same basename — the data is currently
+  self-consistent (and the file is now correctly named `…_Aryan,_Elis.NEF`).
+- **attempt_stats.jsonl**: three review records for the same physical image (hash
+  `531d80…`). The record whose filename is `260111_080910_Aryan.NEF` post-dates the rename;
+  the pre-rename record (`260111_080910-1.NEF`, same hash) lists `[Aryan, Elis, ignorerad]`.
+
+Conclusion: the rename that produced `_Aryan` ran before "Elis" was persisted to either
+store (an ordering trigger), while the two structural defects removed the safety nets that
+would otherwise have recovered the name. The fixes below make the data model robust so a
+re-rename heals such cases and a singly-anchored manual face is never dropped again.
+
+## Fix (implemented)
+
+### Change 1 — anchor manual encodings by content hash
+`backend/api/services/detection_service.py`, `_confirm_identity_nosave` manual branch:
+compute `get_file_hash(image_path)` (mirrors the single-call path) instead of `hash=None`.
+Manual faces become hash-anchored → survive renames and basename divergence.
+
+### Change 2 — union basename + hash lookup
+`backend/api/services/rename_service.py`, `collect_persons_for_files`: replace the
+`if not encoding_persons` fallback with a deduped **union** of basename- and hash-matched
+names, so a face anchored by only one key is never suppressed by a match on the other. This
+also heals existing data: `_update_database_paths` keeps manual entries' basename current,
+so even legacy `hash=None` entries are recovered by basename.
+
+### Change 3 — CLI parity
+`backend/hitta_ansikten.py`, the near-identical `collect_persons_for_files`: same union
+change so the legacy CLI rename behaves identically.
+
+## Tests
+
+`backend/tests/test_rename_service.py`:
+- `test_manual_face_hash_only_not_suppressed_by_basename` — the decisive regression for
+  defect #2 (fails before Change 2).
+- `test_legacy_manual_face_hash_none_recovered_by_basename` — legacy `hash=None` entry still
+  recovered.
+- `test_union_does_not_duplicate_when_both_keys_match` — no duplication.
+
+`backend/tests/test_detection_manual_confirm.py`:
+- `test_manual_confirm_anchors_content_hash` — Change 1: manual confirm stores the file's
+  content hash, not None.
+- `test_manual_confirm_missing_file_keeps_hash_none` — graceful fallback when file absent.
+
+Run: `cd backend && pytest` (23 passed) and `cd frontend && npm test` (18 passed).
+
+## Follow-up (logged in TODO.md)
+
+The structural fix is durable, but the underlying *ordering* trigger (a rename reading the
+DB before a just-added manual face is persisted) is a frontend sequencing concern; the
+auto-save → rename path (`c7564d3`) should be audited to guarantee the manual confirm and
+`mark_review_complete` always complete before a rename can run.

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,8 @@ Konsoliderad lista över planerade förbättringar, kända brister och teknisk s
 
 ### Nu
 
-- [ ] Rename bugfix. Jag kan ha fel, men jag *tror* att rename inte beaktar manuellt tillagda ansikten/namn? Exempelvis filen ~/Pictures/nerladdat/260111_080910_Aryan.NEF. Den har döpts om enligt ovan. Aryan är ett hittat och bekräftat ansikte---men manuellt har även Elis lagts till. Ändå blir det nya filnamnet endast Aryan; inte Elis. Något är fel! Undersök vad och åtgärda buggen! /plan deepthink Skriv ner planen i en .md för ändamålet i reporoten.
+- [x] **Rename bugfix — manuellt tillagda ansikten tappades ur filnamnet** (2026-06-29). Manuella ansikten sparades med `hash=None` i batch-confirm (GUI), och rename-uppslaget använde hash-indexet bara som fallback (inte union), så ett ansikte som var ankrat via endast en nyckel kunde tappas. Fix: ankra manuella ansikten på content-hash + union av basename-/hash-träffar i `collect_persons_for_files` (både GUI och legacy-CLI). Plan + diagnos: [RENAME_MANUAL_FACES_PLAN.md](RENAME_MANUAL_FACES_PLAN.md).
+  - [ ] **Följdspår: ordnings-/race-granskning av auto-save → rename** — den strukturella fixen är robust, men den faktiska historiska triggern var att rename läste databasen innan ett nyss tillagt manuellt ansikte hunnit persisteras. Granska auto-save→rename-vägen (`c7564d3`) så att manuell confirm + `mark_review_complete` alltid hinner klart före rename. Egen PR.
 
 ### Kort sikt
 

--- a/backend/api/services/detection_service.py
+++ b/backend/api/services/detection_service.py
@@ -780,10 +780,15 @@ class DetectionService:
         """In-memory confirm without saving to disk. Returns result dict."""
         if face_id.startswith("manual_"):
             backend_info = self.backend.get_model_info()
+            # Anchor manual faces by content hash (like detected faces) so the rename
+            # pipeline can recover the name by hash even after the file is renamed —
+            # mirrors the single-call confirm_identity path.
+            path = Path(image_path)
+            file_hash = get_file_hash(path) if path.exists() else None
             entry = {
                 "encoding": None,
                 "file": str(image_path),
-                "hash": None,
+                "hash": file_hash,
                 "backend": self.backend.backend_name,
                 "backend_version": backend_info.get("version", "unknown"),
                 "created_at": datetime.now().isoformat(),

--- a/backend/api/services/rename_service.py
+++ b/backend/api/services/rename_service.py
@@ -634,9 +634,14 @@ def collect_persons_for_files(
         fname = fpath.name
         h = filehash_map.get(str(fpath)) or processed_name_to_hash.get(fname)
 
-        encoding_persons = file_to_persons.get(fname, [])
-        if not encoding_persons and h:
-            encoding_persons = hash_to_persons.get(h, [])
+        # Union of basename- and hash-matched names (deduped). Manual faces may be
+        # anchored by only one key (legacy entries have hash=None → basename-only),
+        # so a hash-only match must not be suppressed by a basename match, or vice versa.
+        encoding_persons = list(file_to_persons.get(fname, []))
+        if h:
+            for name in hash_to_persons.get(h, []):
+                if name not in encoding_persons:
+                    encoding_persons.append(name)
 
         review_persons = []
         if h and h in stats_by_hash:

--- a/backend/hitta_ansikten.py
+++ b/backend/hitta_ansikten.py
@@ -984,9 +984,14 @@ def collect_persons_for_files(
         fname = Path(f).name
         h = filehash_map.get(fname) or processed_name_to_hash.get(fname)
 
-        encoding_persons = file_to_persons.get(fname, [])
-        if not encoding_persons and h:
-            encoding_persons = hash_to_persons.get(h, [])
+        # Union of basename- and hash-matched names (deduped) — see rename_service.py.
+        # Manual faces may be anchored by only one key, so neither match must be
+        # suppressed by the other.
+        encoding_persons = list(file_to_persons.get(fname, []))
+        if h:
+            for name in hash_to_persons.get(h, []):
+                if name not in encoding_persons:
+                    encoding_persons.append(name)
 
         review_persons = []
         if h and h in stats_by_hash:

--- a/backend/tests/test_detection_manual_confirm.py
+++ b/backend/tests/test_detection_manual_confirm.py
@@ -1,0 +1,45 @@
+"""Tests for DetectionService manual-face confirmation.
+
+Regression: manually added faces must be persisted with the file's content hash
+(like detected faces), so the rename pipeline can recover them by hash even after
+the file is renamed. The batch-confirm path previously stored hash=None.
+"""
+
+from unittest.mock import MagicMock
+
+from api.services.detection_service import DetectionService
+from faceid_db import get_file_hash
+
+
+def _service():
+    """A DetectionService with the backend mocked, bypassing model loading."""
+    svc = DetectionService.__new__(DetectionService)
+    svc.known_faces = {}
+    svc.backend = MagicMock()
+    svc.backend.backend_name = "insightface"
+    svc.backend.get_model_info.return_value = {"version": "test"}
+    return svc
+
+
+def test_manual_confirm_anchors_content_hash(tmp_path):
+    img = tmp_path / "260111_080910.NEF"
+    img.write_bytes(b"nef-bytes")
+    svc = _service()
+
+    svc._confirm_identity_nosave("manual_1", "Elis", str(img))
+
+    entry = svc.known_faces["Elis"][0]
+    assert entry["is_manual"] is True
+    assert entry["encoding"] is None
+    # Hash is the file's content hash, not None — this is the fix.
+    assert entry["hash"] == get_file_hash(img)
+    assert entry["hash"] is not None
+
+
+def test_manual_confirm_missing_file_keeps_hash_none(tmp_path):
+    """If the source file is gone, fall back gracefully to hash=None rather than crash."""
+    svc = _service()
+
+    svc._confirm_identity_nosave("manual_1", "Elis", str(tmp_path / "absent.NEF"))
+
+    assert svc.known_faces["Elis"][0]["hash"] is None

--- a/backend/tests/test_rename_service.py
+++ b/backend/tests/test_rename_service.py
@@ -143,6 +143,74 @@ class TestCollectPersonsForFiles:
 
         assert result[str(test_file)] == ["Encoding Person"]
 
+    def test_manual_face_hash_only_not_suppressed_by_basename(self, tmp_path):
+        """A manual face anchored only by hash must survive when another face matches
+        by basename.
+
+        Regression for the reported bug: after a file is renamed, the auto-detected
+        face's encoding points to the current basename while the manually added face's
+        encoding diverges (e.g. it still carries the pre-rename basename, or only a
+        hash). The old fallback consulted the hash index only when the basename index
+        was empty, so the basename hit for the detected face silently dropped the
+        manual face. The lookup is now a union of both indexes.
+        """
+        test_file = tmp_path / "260111_080910_Aryan.NEF"
+        test_file.touch()
+        known_faces = {
+            # Detected face: encoding basename matches the current filename.
+            "Aryan": [{"file": "260111_080910_Aryan.NEF", "hash": "H", "encoding": [0.1]}],
+            # Manual face: encoding basename has diverged, only the hash still matches.
+            "Elis": [{"file": "260111_080910.NEF", "hash": "H",
+                      "encoding": None, "is_manual": True}],
+        }
+        filelist = [str(test_file)]
+
+        with patch("api.services.rename_service.get_file_hash", return_value="H"):
+            result = collect_persons_for_files(filelist, known_faces, attempt_log=[])
+
+        assert result[str(test_file)] == ["Aryan", "Elis"]
+
+    def test_legacy_manual_face_hash_none_recovered_by_basename(self, tmp_path):
+        """A legacy manual entry (hash=None) is still recovered via the basename index
+        alongside a detected face on the same file."""
+        test_file = tmp_path / "260111_080910_Aryan.NEF"
+        test_file.touch()
+        known_faces = {
+            "Aryan": [{"file": "260111_080910_Aryan.NEF", "hash": "H", "encoding": [0.1]}],
+            "Elis": [{"file": "260111_080910_Aryan.NEF", "hash": None,
+                      "encoding": None, "is_manual": True}],
+        }
+        filelist = [str(test_file)]
+
+        with patch("api.services.rename_service.get_file_hash", return_value="H"):
+            result = collect_persons_for_files(filelist, known_faces, attempt_log=[])
+
+        assert result[str(test_file)] == ["Aryan", "Elis"]
+
+    def test_union_does_not_duplicate_when_both_keys_match(self, tmp_path):
+        """A face matched by both basename and hash appears once, and merging with
+        review data does not duplicate it."""
+        test_file = tmp_path / "IMG_0001.NEF"
+        test_file.touch()
+        known_faces = {
+            "Aryan": [{"file": "IMG_0001.NEF", "hash": "H", "encoding": [0.1]}],
+        }
+        filelist = [str(test_file)]
+        attempt_log = [
+            {
+                "filename": str(test_file),
+                "file_hash": "H",
+                "used_attempt": 0,
+                "review_results": ["ok"],
+                "labels_per_attempt": [[{"label": "#1\nAryan"}]],
+            },
+        ]
+
+        with patch("api.services.rename_service.get_file_hash", return_value="H"):
+            result = collect_persons_for_files(filelist, known_faces, attempt_log=attempt_log)
+
+        assert result[str(test_file)] == ["Aryan"]
+
     def test_ignored_labels_filtered(self, tmp_path):
         """Labels marked as ignored should not be included."""
         known_faces = {}


### PR DESCRIPTION
## Problem

Renaming a NEF kept auto-detected + confirmed faces in the new filename but **dropped manually added faces**. Reported example: a file where "Aryan" was auto-detected+confirmed and "Elis" was added manually renamed to only `…_Aryan`, dropping "Elis". (CHANGELOG 1.1.0's "include manual faces" merge logic was present and correct, but a data-model gap underneath it still dropped them.)

## Root cause

`collect_persons_for_files` (`rename_service.py`) merges names from `encodings.pkl`, `attempt_stats.jsonl`, and `processed_files.jsonl`. A detected face is double-anchored (real `hash` + `file`, plus an attempt-stats record by content hash). A manual face was fragilely single-anchored because of two interacting defects:

1. The GUI batch-confirm path stored manual encodings with `hash=None`, so they were indexed only by basename — recoverable only by an exact current-basename match.
2. The lookup consulted the hash index **only as a fallback** (`if not encoding_persons and h:`), so once the detected face was found by basename the hash branch was skipped, dropping a hash-only-anchored manual face.

`attempt_stats.jsonl` is the remaining safety net, so the bug surfaced when that also missed — chiefly when the rename ran before the manual confirm was persisted (an ordering trigger), confirmed by inspecting the reported file's real data.

## Fix

- **Anchor manual faces by content hash** (`detection_service.py`) — mirror the single-call path instead of `hash=None`.
- **Union basename + hash matches** (`rename_service.py`, deduped) instead of fallback, so a face anchored by only one key is never suppressed. This also heals existing data (basename is kept current on rename).
- **CLI parity** — same union change in the legacy `hitta_ansikten.py` copy.

## Tests

New regression tests (the decisive one fails before the union change); full suites green: backend 23 passed, frontend 18 passed.

## Notes

Plan + diagnostic findings: `RENAME_MANUAL_FACES_PLAN.md`. A follow-up to audit the auto-save → rename ordering is logged in TODO.md.