### PR TITLE
Document manual-face encoding entries in database.md

### DIFF
--- a/docs/dev/database.md
+++ b/docs/dev/database.md
@@ -58,6 +58,13 @@ Known faces database. Dictionary mapping person names to encoding lists.
 - One person can have multiple encodings from different images
 - dlib encodings (128-dim) are deprecated and auto-removed at server startup
 
+**Manual faces.** A face added by hand in review (not auto-detected) is stored as an
+entry with `encoding: None`, `encoding_hash: None`, `bounding_box: None`, and
+`is_manual: True`. It still records `file` and the source file's content `hash` — the
+hash anchors the name to the image so the rename pipeline recovers it even after the file
+is renamed (rename matches by hash and basename). A manual entry has no vector, so it
+never participates in matching; it only carries the name → file association.
+
 ### ignored.pkl
 
 List of ignored face encodings.


### PR DESCRIPTION
Pure-docs follow-up to PR #56 (rename: keep manually added faces in the filename).

The `encodings.pkl` schema in `docs/dev/database.md` never documented manual-face entries. Adds a short, accurate note: a manually added face is stored with `encoding: None`, `encoding_hash: None`, `bounding_box: None`, `is_manual: True`, and now records `file` + the source file's content `hash` — the hash anchors the name to the image so rename recovers it after a rename. Fields verified against `detection_service._confirm_identity_nosave`.

Docs only — no code change, no review loop needed.