### PR TITLE
Hold files with unsaved review changes out of rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ### Fixed
 - Rename now keeps manually added faces in the new filename. Manual faces are persisted with the file's content hash (the batch-confirm path previously stored `hash=None`), and the rename name lookup now takes the union of basename- and hash-matched names instead of consulting the hash index only as a fallback — so a manual face anchored by only one key is no longer dropped when an auto-detected face matches by the other. Applies to both the GUI and the legacy CLI rename.
+- Rename now holds a file out of name resolution while its review has unsaved changes, closing the ordering window behind the fix above: adding a manual face to an already-processed file and renaming during the brief save window could read the database before the face persisted and drop it from the first-pass filename. The Review panel signals unsaved changes and the file queue excludes such files from rename preview and execution until the save completes.
 - Gallra spelare CSS referenced undefined `--border-color` / `--accent` variables, so borders fell back to nothing and the active file row rendered a non-theme blue; it now uses the theme variables (the active row uses the theme accent in both light and dark).
 
 ## [1.3.0] - 2026-06-27

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@ Konsoliderad lista över planerade förbättringar, kända brister och teknisk s
 ### Nu
 
 - [x] **Rename bugfix — manuellt tillagda ansikten tappades ur filnamnet** (2026-06-29). Manuella ansikten sparades med `hash=None` i batch-confirm (GUI), och rename-uppslaget använde hash-indexet bara som fallback (inte union), så ett ansikte som var ankrat via endast en nyckel kunde tappas. Fix: ankra manuella ansikten på content-hash + union av basename-/hash-träffar i `collect_persons_for_files` (både GUI och legacy-CLI). Plan + diagnos: [RENAME_MANUAL_FACES_PLAN.md](RENAME_MANUAL_FACES_PLAN.md).
-  - [ ] **Följdspår: ordnings-/race-granskning av auto-save → rename** — den strukturella fixen är robust, men den faktiska historiska triggern var att rename läste databasen innan ett nyss tillagt manuellt ansikte hunnit persisteras. Granska auto-save→rename-vägen (`c7564d3`) så att manuell confirm + `mark_review_complete` alltid hinner klart före rename. Egen PR.
+  - [x] **Följdspår: ordnings-/race-granskning av auto-save → rename** (2026-06-29) — granskning bekräftade att normalflödet redan är säkert (status blir `completed` först efter att `saveAllChanges` + `mark_review_complete` awaitats), och att rename bara triggas via knapp. Kvarvarande fönster: ett redan processat filobjekt kunde namnges medan en andra-spar pågick (`isAlreadyProcessed`-vägen var inte gateadd). Fix: Review-panelen signalerar `review-dirty` när det finns osparade ändringar, och fillistan håller dirty-filer utanför rename-preview/-exekvering tills sparningen är klar. Frontend-only; data-modellen orörd.
 
 ### Kort sikt
 

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -17,7 +17,7 @@ import { debug, debugWarn, debugError } from '../shared/debug.js';
 import { apiClient } from '../shared/api-client.js';
 import { getPreprocessingManager, PreprocessingStatus } from '../services/preprocessing/index.js';
 import { Icon } from './Icon.jsx';
-import { isFileEligible as isFileEligiblePure, findNextEligibleIndex } from './fileQueueEligibility.js';
+import { isFileEligible as isFileEligiblePure, findNextEligibleIndex, isRenameEligible } from './fileQueueEligibility.js';
 import { compileFilter } from './filterExpression.js';
 import { formatNamesToFit, measureTextWidth } from '../shared/nameFormatter.js';
 import './FileQueueModule.css';
@@ -233,6 +233,10 @@ export function FileQueueModule({ node }) {
   const [showPreviewNames, setShowPreviewNames] = useState(false);
   const [previewData, setPreviewData] = useState(null); // { path: { newName, status, persons } }
   const [renameInProgress, setRenameInProgress] = useState(false);
+  // Paths whose review has unsaved changes; held out of rename until persisted.
+  const [dirtyPaths, setDirtyPaths] = useState(new Set());
+  const dirtyPathsRef = useRef(dirtyPaths);
+  dirtyPathsRef.current = dirtyPaths;
 
   // Drag-and-drop state
   const [isDragOver, setIsDragOver] = useState(false);
@@ -1359,8 +1363,9 @@ export function FileQueueModule({ node }) {
     // - isAlreadyProcessed (when fix-mode OFF): already in database, includes active files being re-viewed
     const currentQueue = queueRef.current;
     const currentFixMode = fixModeRef.current;
+    const dirty = dirtyPathsRef.current;
     const eligiblePaths = currentQueue
-      .filter(q => q.status === 'completed' || (!currentFixMode && q.isAlreadyProcessed))
+      .filter(q => isRenameEligible(q, currentFixMode, dirty))
       .map(q => q.filePath);
 
     if (eligiblePaths.length === 0) {
@@ -1449,7 +1454,7 @@ export function FileQueueModule({ node }) {
     const currentVisibleIds = visibleIdsRef.current;
     const eligiblePaths = queue
       .filter(q => {
-        const isEligible = q.status === 'completed' || (!currentFixMode && q.isAlreadyProcessed);
+        const isEligible = isRenameEligible(q, currentFixMode, dirtyPathsRef.current);
         if (hasSelection) return isEligible && selectedFiles.has(q.id);
         if (currentVisibleIds) return isEligible && currentVisibleIds.has(q.id);
         return isEligible;
@@ -1558,6 +1563,14 @@ export function FileQueueModule({ node }) {
   useModuleEvent('review-complete', useCallback(({ imagePath, success, reviewedFaces }) => {
     debug('FileQueue', 'Review complete:', imagePath, success, 'faces:', reviewedFaces?.length);
 
+    // The review is persisted by the time this fires, so the file is safe to rename again.
+    setDirtyPaths(prev => {
+      if (!prev.has(imagePath)) return prev;
+      const next = new Set(prev);
+      next.delete(imagePath);
+      return next;
+    });
+
     if (success && preprocessingManager.current) {
       preprocessingManager.current.markDone(imagePath);
     }
@@ -1632,6 +1645,20 @@ export function FileQueueModule({ node }) {
       }
     }
   }, [autoAdvance, loadFile, loadProcessedFiles, showToast, emit, isFileEligible]));
+
+  // Track files whose review has unsaved changes; while dirty they're held out of
+  // rename so a rename can't read the database before a just-added manual face persists.
+  useModuleEvent('review-dirty', useCallback(({ imagePath, dirty }) => {
+    if (!imagePath) return;
+    setDirtyPaths(prev => {
+      const has = prev.has(imagePath);
+      if (dirty === has) return prev;
+      const next = new Set(prev);
+      if (dirty) next.add(imagePath);
+      else next.delete(imagePath);
+      return next;
+    });
+  }, []));
 
   // Listen for faces-detected event to update face count for the detected file
   // This updates the face count when detection completes (not just from preprocessing)
@@ -2157,7 +2184,7 @@ export function FileQueueModule({ node }) {
           <div className="file-queue-controls">
             {(() => {
               const hasSelection = selectedFiles.size > 0;
-              const isEligible = q => q.status === 'completed' || (!fixMode && q.isAlreadyProcessed);
+              const isEligible = q => isRenameEligible(q, fixMode, dirtyPaths);
               let renameCount, renameLabel;
               if (hasSelection) {
                 renameCount = queue.filter(q => selectedFiles.has(q.id) && isEligible(q)).length;

--- a/frontend/src/renderer/components/FileQueueModule.jsx
+++ b/frontend/src/renderer/components/FileQueueModule.jsx
@@ -2193,7 +2193,9 @@ export function FileQueueModule({ node }) {
                 renameCount = queue.filter(q => visibleIds.has(q.id) && isEligible(q)).length;
                 renameLabel = `Rename (${renameCount} filtered)`;
               } else {
-                renameCount = completedCount;
+                // Use the gated predicate (not completedCount) so the count excludes
+                // files transiently held out of rename by unsaved review changes.
+                renameCount = queue.filter(isEligible).length;
                 renameLabel = `Rename (${renameCount})`;
               }
               return renameCount > 0 && (

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -696,6 +696,31 @@ export function ReviewModule({ node }) {
   }, [detectedFaces, pendingConfirmations, pendingIgnores, saveAllChanges, buildReviewedFaces, markReviewComplete, emit, currentImagePath, currentFileHash]);
 
   /**
+   * Signal "dirty" state for the current file so the file queue can hold it out of
+   * rename until the review is persisted. Pending confirmations/ignores are cleared
+   * only after the batch save succeeds, so a non-empty pending set is exactly the
+   * window where the database has not yet caught up with the user's edits — renaming
+   * during it would drop a just-added (but unsaved) manual face from the filename.
+   */
+  useEffect(() => {
+    if (!currentImagePath) return;
+    const dirty = pendingConfirmations.length + pendingIgnores.length > 0;
+    emit('review-dirty', { imagePath: currentImagePath, dirty });
+  }, [pendingConfirmations.length, pendingIgnores.length, currentImagePath, emit]);
+
+  /**
+   * Clear the dirty flag for a file when the user leaves it (manual file switch that
+   * bypasses saveAllChanges), so a file is never stuck unrenamable. review-complete
+   * also clears it on the normal save path.
+   */
+  useEffect(() => {
+    const leftPath = currentImagePath;
+    return () => {
+      if (leftPath) emit('review-dirty', { imagePath: leftPath, dirty: false });
+    };
+  }, [currentImagePath, emit]);
+
+  /**
    * Update status when pending changes
    */
   useEffect(() => {

--- a/frontend/src/renderer/components/fileQueueEligibility.js
+++ b/frontend/src/renderer/components/fileQueueEligibility.js
@@ -22,6 +22,27 @@ export function isFileEligible(item, context) {
 }
 
 /**
+ * Determine if a queue item is eligible for the face-based rename.
+ *
+ * Rename targets files whose review is done (`status === 'completed'`) or that are
+ * already in the database (`isAlreadyProcessed`, when not in fix-mode). A file with
+ * unsaved review changes (in `dirtyPaths`) is held out until its review is persisted,
+ * so a rename never reads the database before a just-added manual face has been saved.
+ *
+ * @param {Object} item - Queue item with status, isAlreadyProcessed, filePath
+ * @param {boolean} fixMode - Whether fix-mode (re-review) is on
+ * @param {Set<string>} [dirtyPaths] - filePaths with unsaved review changes
+ * @returns {boolean}
+ */
+export function isRenameEligible(item, fixMode, dirtyPaths) {
+  if (!item) return false;
+  const eligible = item.status === 'completed' || (!fixMode && item.isAlreadyProcessed);
+  if (!eligible) return false;
+  if (dirtyPaths && dirtyPaths.has(item.filePath)) return false;
+  return true;
+}
+
+/**
  * Find the index of the next eligible file in the queue.
  * @param {Array} queue - Array of queue items
  * @param {Object} context - Context with fixMode and processedFiles Set

--- a/frontend/tests/fileQueueEligibility.test.js
+++ b/frontend/tests/fileQueueEligibility.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { isRenameEligible } from '../src/renderer/components/fileQueueEligibility.js';
+
+describe('fileQueueEligibility', () => {
+  describe('isRenameEligible', () => {
+    const completed = { status: 'completed', isAlreadyProcessed: false, filePath: '/a.NEF' };
+    const processed = { status: 'pending', isAlreadyProcessed: true, filePath: '/b.NEF' };
+    const fresh = { status: 'pending', isAlreadyProcessed: false, filePath: '/c.NEF' };
+
+    it('returns false for a missing item', () => {
+      expect(isRenameEligible(null, false, new Set())).toBe(false);
+      expect(isRenameEligible(undefined, false, new Set())).toBe(false);
+    });
+
+    it('treats a completed file as eligible regardless of fix-mode', () => {
+      expect(isRenameEligible(completed, false, new Set())).toBe(true);
+      expect(isRenameEligible(completed, true, new Set())).toBe(true);
+    });
+
+    it('treats an already-processed file as eligible only when fix-mode is off', () => {
+      expect(isRenameEligible(processed, false, new Set())).toBe(true);
+      expect(isRenameEligible(processed, true, new Set())).toBe(false);
+    });
+
+    it('treats an unreviewed, unprocessed file as not eligible', () => {
+      expect(isRenameEligible(fresh, false, new Set())).toBe(false);
+      expect(isRenameEligible(fresh, true, new Set())).toBe(false);
+    });
+
+    it('excludes an otherwise-eligible file while it has unsaved review changes', () => {
+      const dirty = new Set(['/a.NEF', '/b.NEF']);
+      // The regression: a file with a just-added (unsaved) manual face must not be
+      // renamed until its review persists.
+      expect(isRenameEligible(completed, false, dirty)).toBe(false);
+      expect(isRenameEligible(processed, false, dirty)).toBe(false);
+    });
+
+    it('tolerates an omitted dirtyPaths argument', () => {
+      expect(isRenameEligible(completed, false)).toBe(true);
+      expect(isRenameEligible(processed, false, undefined)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes the follow-up logged under TODO.md "Nu" to the manual-face rename fix (#56).

## Problem

The structural fix in #56 made the data model robust and self-healing, but a narrow ordering window remained. Rename is user-button-only and eligibility includes `(!fixMode && isAlreadyProcessed)`, so an **already-processed** file could be renamed while a *second* review-save was still in flight — adding a manual face to such a file and renaming during the ~1 s save window let the rename read the database before the manual face persisted, dropping it from the first-pass filename (healed only on re-rename). `c7564d3` guarded the auto-save snapshot but not a rename clicked during a save.

The normal first-review flow was already safe: a file's status flips to `completed` only after ReviewModule awaits `saveAllChanges` + `markReviewComplete`.

## Fix

- **ReviewModule** emits a `review-dirty` signal whenever there are pending (unsaved) confirmations/ignores — precisely the window before `saveAllChanges` clears them — and clears it on file switch.
- **FileQueue** tracks dirty paths and excludes them from rename **preview and execution** (and the rename button count), via a new pure `isRenameEligible` predicate shared across the rename sites. Cleared again on `review-complete`.

A dirty file becomes renamable the moment its save persists. Batch renames of other completed files are unaffected. Frontend-only; the data model is unchanged.

## Tests

- New `frontend/tests/fileQueueEligibility.test.js` unit-tests `isRenameEligible`, including the regression: a dirty path is excluded even when otherwise eligible.
- `cd frontend && npm test` → 24 passed. `cd backend && pytest` → 23 passed (backend untouched).