### PR TITLE
(gitignore) Ignore node_modules at any level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .DS_Store
 SESSION_SUMMARY.md
 tmp
+node_modules/


### PR DESCRIPTION
Root `.gitignore` had no `node_modules` rule (only `frontend/.gitignore` did), so a root-level `node_modules/` (e.g. a vitest cache) showed up as untracked and could be accidentally committed. Add `node_modules/` to the root `.gitignore` — matches node_modules at any depth.