### PR TITLE
i18n: Swedish Statistics / Log Viewer / ConnectionStatus

### DIFF
--- a/frontend/src/i18n/sv/connection.js
+++ b/frontend/src/i18n/sv/connection.js
@@ -1,2 +1,5 @@
-// Swedish catalog namespace: connection (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: connection
+module.exports = {
+  "unreachable": "Servern kan inte nås – kontrollera din anslutning",
+  "connecting": "Ansluter till servern…"
+};

--- a/frontend/src/i18n/sv/logs.js
+++ b/frontend/src/i18n/sv/logs.js
@@ -1,2 +1,27 @@
-// Swedish catalog namespace: logs (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: logs
+module.exports = {
+  "title": "Loggar",
+
+  "source": {
+    "all": "Alla källor",
+    "backend": "Server",
+    "frontend": "Gränssnitt"
+  },
+
+  "level": {
+    "all": "Alla nivåer",
+    "debug": "Felsökning",
+    "info": "Information",
+    "warning": "Varning",
+    "error": "Fel"
+  },
+
+  "copy": "Kopiera",
+  "copied": "Kopierat!",
+  "clear": "Rensa",
+
+  "empty": {
+    "waiting": "Väntar på loggposter…",
+    "noMatch": "Inga loggposter matchar det aktuella filtret"
+  }
+};

--- a/frontend/src/i18n/sv/statistics.js
+++ b/frontend/src/i18n/sv/statistics.js
@@ -1,2 +1,36 @@
-// Swedish catalog namespace: statistics (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: statistics
+module.exports = {
+  "title": "Statistik",
+
+  "autoRefresh": "Automatisk uppdatering",
+  "refreshNow": "Uppdatera nu",
+
+  "emptyState": {
+    "line1": "Alla sektioner på panelen är dolda.",
+    "line2": "Aktivera sektioner i Inställningar → Statistik."
+  },
+
+  "sections": {
+    "attemptStats": "Detekteringsstatistik",
+    "topFaces": "Toppansikten ({count} vanligaste + Ignorerade)",
+    "recentImages": "Senaste bilder",
+    "recentLogs": "Senaste loggrader"
+  },
+
+  "table": {
+    "backendSettings": "Server & inställningar",
+    "attempts": "Försök",
+    "chosen": "Valda",
+    "hitRate": "Träff %",
+    "avgFaces": "Snitt ansikten",
+    "avgTime": "Snitt tid"
+  },
+
+  "loading": "Laddar…",
+
+  "empty": {
+    "attemptStats": "Ingen detekteringsstatistik tillgänglig",
+    "recentImages": "Inga bilder ännu",
+    "recentLogs": "Inga loggar ännu"
+  }
+};

--- a/frontend/src/i18n/sv/statistics.js
+++ b/frontend/src/i18n/sv/statistics.js
@@ -1,6 +1,7 @@
 // Swedish catalog namespace: statistics
 module.exports = {
   "title": "Statistik",
+  "ignored": "Ignorerade",
 
   "autoRefresh": "Automatisk uppdatering",
   "refreshNow": "Uppdatera nu",

--- a/frontend/src/renderer/components/ConnectionStatus.jsx
+++ b/frontend/src/renderer/components/ConnectionStatus.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { useBackend } from '../context/BackendContext.jsx';
+import { t } from '../../i18n/index.js';
 import './ConnectionStatus.css';
 
 export function ConnectionStatus() {
@@ -14,8 +15,8 @@ export function ConnectionStatus() {
   }
 
   const message = isOffline
-    ? 'Backend unreachable - check your connection'
-    : 'Connecting to backend...';
+    ? t('connection.unreachable')
+    : t('connection.connecting');
 
   return (
     <div className="connection-status-banner">

--- a/frontend/src/renderer/components/LogViewer.jsx
+++ b/frontend/src/renderer/components/LogViewer.jsx
@@ -12,6 +12,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useWebSocket } from '../hooks/useWebSocket.js';
 import { getLogBuffer, clearLogBuffer, debug } from '../shared/debug.js';
+import { t } from '../../i18n/index.js';
 import './LogViewer.css';
 
 /**
@@ -170,33 +171,33 @@ export function LogViewer() {
   return (
     <div className="module-container log-viewer">
       <div className="module-header">
-        <h3 className="module-title">Logs</h3>
+        <h3 className="module-title">{t('logs.title')}</h3>
         <div className="button-group">
           <select
             className="form-select"
             value={filterSource}
             onChange={(e) => setFilterSource(e.target.value)}
           >
-            <option value="all">All Sources</option>
-            <option value="backend">Backend</option>
-            <option value="frontend">Frontend</option>
+            <option value="all">{t('logs.source.all')}</option>
+            <option value="backend">{t('logs.source.backend')}</option>
+            <option value="frontend">{t('logs.source.frontend')}</option>
           </select>
           <select
             className="form-select"
             value={filterLevel}
             onChange={(e) => setFilterLevel(e.target.value)}
           >
-            <option value="all">All Levels</option>
-            <option value="debug">Debug</option>
-            <option value="info">Info</option>
-            <option value="warn">Warning</option>
-            <option value="error">Error</option>
+            <option value="all">{t('logs.level.all')}</option>
+            <option value="debug">{t('logs.level.debug')}</option>
+            <option value="info">{t('logs.level.info')}</option>
+            <option value="warn">{t('logs.level.warning')}</option>
+            <option value="error">{t('logs.level.error')}</option>
           </select>
           <button type="button" className="btn-secondary" onClick={copyLogs}>
-            {copyFeedback ? 'Copied!' : 'Copy'}
+            {copyFeedback ? t('logs.copied') : t('logs.copy')}
           </button>
           <button type="button" className="btn-secondary" onClick={clearLogs}>
-            Clear
+            {t('logs.clear')}
           </button>
         </div>
       </div>
@@ -209,8 +210,8 @@ export function LogViewer() {
         {filteredLogs.length === 0 ? (
           <div className="empty-state">
             {logs.length === 0
-              ? 'Waiting for log entries...'
-              : 'No log entries match the current filter'}
+              ? t('logs.empty.waiting')
+              : t('logs.empty.noMatch')}
           </div>
         ) : (
           filteredLogs.map(entry => (

--- a/frontend/src/renderer/components/StatisticsDashboard.jsx
+++ b/frontend/src/renderer/components/StatisticsDashboard.jsx
@@ -15,6 +15,7 @@ import { useBackend } from '../context/BackendContext.jsx';
 import { useAutoRefresh } from '../hooks/useAutoRefresh.js';
 import { debug, debugWarn, debugError, getLogBuffer } from '../shared/debug.js';
 import { preferences } from '../workspace/preferences.js';
+import { t } from '../../i18n/index.js';
 import './StatisticsDashboard.css';
 
 /**
@@ -110,7 +111,7 @@ export function StatisticsDashboard() {
   return (
     <div className="module-container stats-dashboard">
       <div className="module-header">
-        <h3 className="module-title">Statistics Dashboard</h3>
+        <h3 className="module-title">{t('statistics.title')}</h3>
         <div className="button-group">
           <label className="form-checkbox">
             <input
@@ -118,7 +119,7 @@ export function StatisticsDashboard() {
               checked={autoRefresh}
               onChange={(e) => setAutoRefresh(e.target.checked)}
             />
-            Auto-refresh
+            {t('statistics.autoRefresh')}
           </label>
           <select
             className="form-select"
@@ -131,7 +132,7 @@ export function StatisticsDashboard() {
             <option value="30000">30s</option>
           </select>
           <button className="btn-secondary" onClick={refresh}>
-            Refresh Now
+            {t('statistics.refreshNow')}
           </button>
         </div>
       </div>
@@ -166,8 +167,8 @@ export function StatisticsDashboard() {
         {/* Show message if all sections are hidden */}
         {!showAttemptStats && !showTopFaces && !showRecentImages && !showRecentLogs && (
           <div className="empty-state">
-            All dashboard sections are hidden.<br/>
-            Enable sections in Preferences → Dashboard.
+            {t('statistics.emptyState.line1')}<br/>
+            {t('statistics.emptyState.line2')}
           </div>
         )}
       </div>
@@ -182,8 +183,8 @@ function AttemptStatsSection({ stats, isLoading }) {
   if (isLoading) {
     return (
       <div className="section-card">
-        <h4 className="section-title">Attempt Statistics</h4>
-        <div className="empty-state compact">Loading...</div>
+        <h4 className="section-title">{t('statistics.sections.attemptStats')}</h4>
+        <div className="empty-state compact">{t('statistics.loading')}</div>
       </div>
     );
   }
@@ -191,24 +192,24 @@ function AttemptStatsSection({ stats, isLoading }) {
   if (!stats || stats.length === 0) {
     return (
       <div className="section-card">
-        <h4 className="section-title">Attempt Statistics</h4>
-        <div className="empty-state compact">No attempt statistics available</div>
+        <h4 className="section-title">{t('statistics.sections.attemptStats')}</h4>
+        <div className="empty-state compact">{t('statistics.empty.attemptStats')}</div>
       </div>
     );
   }
 
   return (
     <div className="section-card">
-      <h4 className="section-title">Attempt Statistics</h4>
+      <h4 className="section-title">{t('statistics.sections.attemptStats')}</h4>
       <table className="attempt-stats-table">
         <thead>
           <tr>
-            <th>Backend &amp; Settings</th>
-            <th className="num">Attempts</th>
-            <th className="num">Chosen</th>
-            <th className="num">Hit %</th>
-            <th className="num">Avg Faces</th>
-            <th className="num">Avg Time</th>
+            <th>{t('statistics.table.backendSettings')}</th>
+            <th className="num">{t('statistics.table.attempts')}</th>
+            <th className="num">{t('statistics.table.chosen')}</th>
+            <th className="num">{t('statistics.table.hitRate')}</th>
+            <th className="num">{t('statistics.table.avgFaces')}</th>
+            <th className="num">{t('statistics.table.avgTime')}</th>
           </tr>
         </thead>
         <tbody>
@@ -241,8 +242,8 @@ function TopFacesSection({ faces, ignoredStats, isLoading }) {
   if (isLoading) {
     return (
       <div className="section-card">
-        <h4 className="section-title">Top Faces (19 most common + Ignored)</h4>
-        <div className="empty-state compact">Loading...</div>
+        <h4 className="section-title">{t('statistics.sections.topFaces', { count: 19 })}</h4>
+        <div className="empty-state compact">{t('statistics.loading')}</div>
       </div>
     );
   }
@@ -275,7 +276,7 @@ function TopFacesSection({ faces, ignoredStats, isLoading }) {
 
   return (
     <div className="section-card">
-      <h4 className="section-title">Top Faces (19 most common + Ignored)</h4>
+      <h4 className="section-title">{t('statistics.sections.topFaces', { count: 19 })}</h4>
       <div className="top-faces-grid">
         {gridItems.map((item, idx) => {
           if (!item) return <div key={idx} className="face-cell">—</div>;
@@ -311,8 +312,8 @@ function RecentImagesSection({ images, isLoading }) {
   if (isLoading) {
     return (
       <div className="section-card">
-        <h4 className="section-title">Recent Images</h4>
-        <div className="empty-state compact">Loading...</div>
+        <h4 className="section-title">{t('statistics.sections.recentImages')}</h4>
+        <div className="empty-state compact">{t('statistics.loading')}</div>
       </div>
     );
   }
@@ -320,15 +321,15 @@ function RecentImagesSection({ images, isLoading }) {
   if (!images || images.length === 0) {
     return (
       <div className="section-card">
-        <h4 className="section-title">Recent Images</h4>
-        <div className="empty-state compact">No recent images</div>
+        <h4 className="section-title">{t('statistics.sections.recentImages')}</h4>
+        <div className="empty-state compact">{t('statistics.empty.recentImages')}</div>
       </div>
     );
   }
 
   return (
     <div className="section-card">
-      <h4 className="section-title">Recent Images</h4>
+      <h4 className="section-title">{t('statistics.sections.recentImages')}</h4>
       <div className="recent-images-list">
         {images.map((img, idx) => (
           <div key={idx} className={`image-entry ${img.source === 'ansikten' ? 'source-ansikten' : 'source-cli'}`}>
@@ -355,8 +356,8 @@ function RecentLogsSection({ logs, isLoading }) {
   if (isLoading) {
     return (
       <div className="section-card">
-        <h4 className="section-title">Recent Log Lines</h4>
-        <div className="empty-state compact">Loading...</div>
+        <h4 className="section-title">{t('statistics.sections.recentLogs')}</h4>
+        <div className="empty-state compact">{t('statistics.loading')}</div>
       </div>
     );
   }
@@ -364,15 +365,15 @@ function RecentLogsSection({ logs, isLoading }) {
   if (!logs || logs.length === 0) {
     return (
       <div className="section-card">
-        <h4 className="section-title">Recent Log Lines</h4>
-        <div className="empty-state compact">No recent logs</div>
+        <h4 className="section-title">{t('statistics.sections.recentLogs')}</h4>
+        <div className="empty-state compact">{t('statistics.empty.recentLogs')}</div>
       </div>
     );
   }
 
   return (
     <div className="section-card">
-      <h4 className="section-title">Recent Log Lines</h4>
+      <h4 className="section-title">{t('statistics.sections.recentLogs')}</h4>
       <div className="recent-logs-list">
         {logs.map((log, idx) => (
           <div key={idx} className={`stats-log-entry ${log.level}`}>

--- a/frontend/src/renderer/components/StatisticsDashboard.jsx
+++ b/frontend/src/renderer/components/StatisticsDashboard.jsx
@@ -286,7 +286,7 @@ function TopFacesSection({ faces, ignoredStats, isLoading }) {
 
           if (item.name) {
             if (item.name === 'Ignored') {
-              content = `${item.name} ${item.face_count}`;
+              content = `${t('statistics.ignored')} ${item.face_count}`;
             } else {
               // Show count and percentage (e.g., "Elton (259, 15%)")
               const pct = item.percentage !== undefined ? `, ${item.percentage}%` : '';


### PR DESCRIPTION
Step 8 of the Swedish sweep — three small admin/status modules in one PR (separate catalog files, no conflicts). statistics.* / logs.* / connection.*. 'backend' = API server → 'Servern' (consistent with FileQueue). Log level/source `value=` kept; display labels translated. All keys resolve; 109 tests green, build clean. (Docs/ROADMAP will be updated in one consolidated PR at the end of the sweep.)