### PR TITLE
i18n: Swedish Review / ImageViewer / OriginalView / StartupStatus / PlayerCount

### DIFF
--- a/frontend/src/i18n/sv/imageViewer.js
+++ b/frontend/src/i18n/sv/imageViewer.js
@@ -1,2 +1,9 @@
-// Swedish catalog namespace: imageViewer (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: imageViewer
+module.exports = {
+  "noImage": "Ingen bild inläst",
+  "openHint": "Öppna en bild för att komma igång",
+  "convertingNef": "Konverterar NEF-fil...",
+  "loadingFromCache": "Laddar från cache...",
+  "unknown": "Okänd",
+  "queueProgress": "{done} klara · {remaining} kvar"
+};

--- a/frontend/src/i18n/sv/originalView.js
+++ b/frontend/src/i18n/sv/originalView.js
@@ -1,2 +1,12 @@
-// Swedish catalog namespace: originalView (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: originalView
+module.exports = {
+  "waiting": "Väntar på NEF-fil...",
+  "loading": "Laddar original...",
+  "notNef": "Inte en NEF-fil",
+  "unknownPath": "Okänd sökväg till original-NEF",
+  "synced": "🔗 Synkroniserad",
+  "detached": "🔓 Frikopplad",
+  "error": "Fel: {message}",
+  "conversionFailed": "NEF-konvertering misslyckades",
+  "loadImageFailed": "Kunde inte ladda bilden"
+};

--- a/frontend/src/i18n/sv/playerCount.js
+++ b/frontend/src/i18n/sv/playerCount.js
@@ -1,2 +1,6 @@
-// Swedish catalog namespace: playerCount (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: playerCount
+module.exports = {
+  // "Per match" kept as-is — established sports term, reads natively in Swedish.
+  "perMatch": "Per match",
+  "matchGap": "Matchgap (min)"
+};

--- a/frontend/src/i18n/sv/review.js
+++ b/frontend/src/i18n/sv/review.js
@@ -1,2 +1,61 @@
-// Swedish catalog namespace: review (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: review
+module.exports = {
+  "placeholder": "Personnamn...",
+  "ignoredBadge": "Ignorerad",
+  "unknown": "Okänd",
+  "noFacesDetected": "Inga ansikten identifierade",
+  "undoTitle": "Dubbelklicka för att ångra",
+
+  "status": {
+    "waitingForImage": "Väntar på bild...",
+    "detecting": "Identifierar ansikten...",
+    "detectionFailed": "Identifiering misslyckades",
+    "detectionCancelled": "Identifiering avbruten",
+    "connectionError": "Anslutningsfel",
+    "found": {
+      "one": "Hittade {count} ansikte ({ms}ms)",
+      "other": "Hittade {count} ansikten ({ms}ms)"
+    },
+    "accepted": "Godkände {accepted}, ignorerade {ignored}",
+    "acceptedSkippedSuffix": ", hoppade över {skipped}",
+    "saving": {
+      "one": "Sparar {count} ändring...",
+      "other": "Sparar {count} ändringar..."
+    },
+    "saved": {
+      "one": "Sparade {count} ändring!",
+      "other": "Sparade {count} ändringar!"
+    },
+    "saveError": "Fel vid sparande – granskningen markerades INTE som klar",
+    "changesDiscarded": "Ändringar kasserade",
+    "imageSkipped": "Bild överhoppad",
+    "manualFaceAdded": "Manuellt ansikte tillagt – ange namn",
+    "reviewProgress": "{reviewed}/{total} granskade | {pending} väntar",
+    "alreadyProcessed": "Redan behandlad – klicka på 🔄 för att behandla om"
+  },
+
+  "toasts": {
+    "noFacesFound": "Inga ansikten hittades i {fileName}",
+    "backendUnreachable": "Servern kan inte nås",
+    "undo": "Ångra: {label}",
+    "undoConfirmFallback": "bekräfta",
+    "undoIgnore": "Ångra: ignorera"
+  },
+
+  "dialogs": {
+    "discardConfirm": {
+      "one": "Kasta {count} osparad ändring?",
+      "other": "Kasta {count} osparade ändringar?"
+    }
+  },
+
+  "dialog": {
+    "confirmNameChange": "Bekräfta namnändring",
+    "confirmIgnore": "Bekräfta ignorering",
+    "bestMatch": "Bästa träff:",
+    "nameMismatch": "Du valde \"{name}\" istället. Är du säker?",
+    "ignoreConfirm": "Du valde att ignorera det här ansiktet. Är du säker?",
+    "hintConfirms": "bekräftar",
+    "hintCancels": "avbryter"
+  }
+};

--- a/frontend/src/i18n/sv/review.js
+++ b/frontend/src/i18n/sv/review.js
@@ -42,13 +42,6 @@ module.exports = {
     "undoIgnore": "Ångra: ignorera"
   },
 
-  "dialogs": {
-    "discardConfirm": {
-      "one": "Kasta {count} osparad ändring?",
-      "other": "Kasta {count} osparade ändringar?"
-    }
-  },
-
   "dialog": {
     "confirmNameChange": "Bekräfta namnändring",
     "confirmIgnore": "Bekräfta ignorering",
@@ -56,6 +49,10 @@ module.exports = {
     "nameMismatch": "Du valde \"{name}\" istället. Är du säker?",
     "ignoreConfirm": "Du valde att ignorera det här ansiktet. Är du säker?",
     "hintConfirms": "bekräftar",
-    "hintCancels": "avbryter"
+    "hintCancels": "avbryter",
+    "discardConfirm": {
+      "one": "Kasta {count} osparad ändring?",
+      "other": "Kasta {count} osparade ändringar?"
+    }
   }
 };

--- a/frontend/src/i18n/sv/startupStatus.js
+++ b/frontend/src/i18n/sv/startupStatus.js
@@ -1,2 +1,20 @@
-// Swedish catalog namespace: startupStatus (to be migrated — see ROADMAP)
-module.exports = {};
+// Swedish catalog namespace: startupStatus
+module.exports = {
+  "labels": {
+    // "Backend" here = the API server, kept consistent with FileQueue/ConnectionStatus.
+    "backend": "Servern",
+    "database": "Databas",
+    "mlModels": "ML-modeller"
+  },
+
+  "status": {
+    "connecting": "Ansluter...",
+    "waiting": "Väntar...",
+    "connected": "Ansluten",
+    "starting": "Startar...",
+    "ready": "Klar",
+    "error": "Startfel"
+  },
+
+  "dismiss": "Klicka för att stänga"
+};

--- a/frontend/src/renderer/components/ImageViewer.jsx
+++ b/frontend/src/renderer/components/ImageViewer.jsx
@@ -16,6 +16,7 @@ import { debug, debugWarn, debugError } from '../shared/debug.js';
 import { apiClient } from '../shared/api-client.js';
 import { preferences } from '../workspace/preferences.js';
 import { LoadingOverlay } from './ProgressBar.jsx';
+import { t } from '../../i18n/index.js';
 import './ImageViewer.css';
 
 // Constants (will be user-configurable in Phase 4)
@@ -96,10 +97,10 @@ export function ImageViewer() {
 
         if (result.status === 'cached') {
           debug('ImageViewer', 'Using cached JPG:', result.nef_jpg_path);
-          setLoadingMessage('Loading from cache...');
+          setLoadingMessage(t('imageViewer.loadingFromCache'));
         } else if (result.status === 'completed') {
           debug('ImageViewer', 'NEF converted and cached:', result.nef_jpg_path);
-          setLoadingMessage('Converting NEF file...');
+          setLoadingMessage(t('imageViewer.convertingNef'));
         } else if (result.status === 'error') {
           throw new Error(result.error || 'NEF conversion failed');
         }
@@ -271,7 +272,7 @@ export function ImageViewer() {
       const getFirstAlternativeName = () => {
         if (face.person_name) return face.person_name;
         const first = face.match_alternatives?.[0];
-        if (!first) return 'Unknown';
+        if (!first) return t('imageViewer.unknown');
         return first.is_ignored ? 'ign' : first.name;
       };
 
@@ -289,7 +290,7 @@ export function ImageViewer() {
           ? `${faceNumber}. ign? (${best.confidence}%)`
           : `${faceNumber}. ${best.name}? (${best.confidence}%)`;
       } else {
-        labelText = `${faceNumber}. Unknown`;
+        labelText = `${faceNumber}. ${t('imageViewer.unknown')}`;
       }
 
       if (labelText) {
@@ -854,19 +855,19 @@ export function ImageViewer() {
       {!image && !isLoading && (
         <div className="image-viewer-placeholder">
           <div className="placeholder-icon">📷</div>
-          <div>No image loaded</div>
-          <div className="placeholder-hint">Open an image to get started</div>
+          <div>{t('imageViewer.noImage')}</div>
+          <div className="placeholder-hint">{t('imageViewer.openHint')}</div>
         </div>
       )}
       {showFileInfo && image && (
         <div className="file-info-overlay">
           <div className="file-info-filename">
-            {originalImagePath?.split('/').pop() || 'Unknown'}
+            {originalImagePath?.split('/').pop() || t('imageViewer.unknown')}
           </div>
           {queueStatus && (
             <div className="file-info-queue">
               <span className="file-info-progress-text">
-                {queueStatus.done} done · {queueStatus.remaining} left
+                {t('imageViewer.queueProgress', { done: queueStatus.done, remaining: queueStatus.remaining })}
               </span>
               <div className="file-info-progress-bar">
                 <div

--- a/frontend/src/renderer/components/OriginalView.jsx
+++ b/frontend/src/renderer/components/OriginalView.jsx
@@ -13,6 +13,7 @@ import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts.js';
 import { useCanvasDimensions } from '../hooks/useCanvas.js';
 import { useBackend } from '../context/BackendContext.jsx';
 import { debug, debugWarn, debugError } from '../shared/debug.js';
+import { t } from '../../i18n/index.js';
 import './OriginalView.css';
 
 // Constants
@@ -47,7 +48,7 @@ export function OriginalView() {
 
   // Loading state
   const [isLoading, setIsLoading] = useState(false);
-  const [placeholder, setPlaceholder] = useState('Waiting for NEF file...');
+  const [placeholder, setPlaceholder] = useState(t('originalView.waiting'));
 
   // Canvas dimensions
   const dimensions = useCanvasDimensions(containerRef);
@@ -67,7 +68,7 @@ export function OriginalView() {
     if (!isNef) {
       debug('OriginalView', 'Not a NEF file, skipping');
       setImage(null);
-      setPlaceholder('Not a NEF file');
+      setPlaceholder(t('originalView.notNef'));
       return;
     }
 
@@ -75,13 +76,13 @@ export function OriginalView() {
     let nefPath = imagePath;
     if (imagePath.includes('_converted.jpg')) {
       debug('OriginalView', 'Converted JPG detected, original path unknown');
-      setPlaceholder('Original NEF path unknown');
+      setPlaceholder(t('originalView.unknownPath'));
       return;
     }
 
     setCurrentNefPath(nefPath);
     setIsLoading(true);
-    setPlaceholder('Loading original...');
+    setPlaceholder(t('originalView.loading'));
 
     try {
       debug('OriginalView', `Loading original: ${nefPath}`);
@@ -90,7 +91,7 @@ export function OriginalView() {
       const result = await api.post('/api/v1/preprocessing/nef', { file_path: nefPath });
 
       if (result.status === 'error') {
-        throw new Error(result.error || 'NEF conversion failed');
+        throw new Error(result.error || t('originalView.conversionFailed'));
       }
 
       const jpgPath = result.nef_jpg_path;
@@ -100,7 +101,7 @@ export function OriginalView() {
       const img = new Image();
       await new Promise((resolve, reject) => {
         img.onload = () => resolve();
-        img.onerror = (err) => reject(new Error('Failed to load image'));
+        img.onerror = (err) => reject(new Error(t('originalView.loadImageFailed')));
         const imageSrc = jpgPath.startsWith('file://') ? jpgPath : 'file://' + jpgPath;
         img.src = imageSrc;
       });
@@ -116,7 +117,7 @@ export function OriginalView() {
     } catch (err) {
       debugError('OriginalView', 'Failed to load original:', err);
       setIsLoading(false);
-      setPlaceholder(`Error: ${err.message}`);
+      setPlaceholder(t('originalView.error', { message: err.message }));
     }
   }, [api]);
 
@@ -346,14 +347,14 @@ export function OriginalView() {
 
       {/* Sync indicator */}
       <div className={`sync-indicator ${isSynced ? 'synced' : 'detached'}`}>
-        {isSynced ? '🔗 Synced' : '🔓 Detached'}
+        {isSynced ? t('originalView.synced') : t('originalView.detached')}
       </div>
 
       {/* Loading/placeholder */}
       {(isLoading || placeholder) && !image && (
         <div className="original-view-placeholder">
           <div className="placeholder-icon">📷</div>
-          <div>{isLoading ? 'Loading original...' : placeholder}</div>
+          <div>{isLoading ? t('originalView.loading') : placeholder}</div>
         </div>
       )}
     </div>

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -12,6 +12,7 @@ import { useBackend } from '../context/BackendContext.jsx';
 import { useModuleAPI } from '../hooks/useModuleEvent.js';
 import { InputBar, EMPTY_INPUT } from './InputBar.jsx';
 import { getScanScope, setScanScope, scanScopeHasSelection, signalExternalLoad } from '../shared/scanScope.js';
+import { t } from '../../i18n/index.js';
 import './PlayerCountModule.css';
 
 const REFRESH_DEBOUNCE_MS = 400;
@@ -345,7 +346,7 @@ export function PlayerCountModule() {
                 if (lastParamsRef.current) submitWith(input, v);
               }}
             />
-            Per match
+            {t('playerCount.perMatch')}
           </label>
           {isRefreshing && <span className="player-count-refreshing">uppdaterar…</span>}
         </div>
@@ -463,7 +464,7 @@ export function CountOptions({
     <div className="player-count-options">
       <div className="player-count-options-row">
         <label className="pc-option">
-          Matchgap (min)
+          {t('playerCount.matchGap')}
           <input
             className="form-input pc-num"
             type="number"

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -569,7 +569,7 @@ export function ReviewModule({ node }) {
   const discardChanges = useCallback(() => {
     if (pendingConfirmations.length === 0 && pendingIgnores.length === 0) return;
 
-    if (!confirm(t('review.dialogs.discardConfirm', { count: pendingConfirmations.length + pendingIgnores.length }))) return;
+    if (!confirm(t('review.dialog.discardConfirm', { count: pendingConfirmations.length + pendingIgnores.length }))) return;
 
     // Reset face states
     setDetectedFaces(prev => prev.map(face => {

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -20,6 +20,7 @@ import { NetworkError } from '../shared/api-client.js';
 import { preferences } from '../workspace/preferences.js';
 import { useThumbnail } from '../shared/thumbnail-cache.js';
 import { Icon } from './Icon.jsx';
+import { t } from '../../i18n/index.js';
 import './ReviewModule.css';
 
 /**
@@ -98,7 +99,7 @@ export function ReviewModule({ node }) {
   const [currentFaceIndex, setCurrentFaceIndex] = useState(0);
   const [pendingConfirmations, setPendingConfirmations] = useState([]);
   const [pendingIgnores, setPendingIgnores] = useState([]);
-  const [status, setStatus] = useState('Waiting for image...');
+  const [status, setStatus] = useState(t('review.status.waitingForImage'));
   const [isLoading, setIsLoading] = useState(false);
   const [clearInputTrigger, setClearInputTrigger] = useState(0);
   const [confirmDialog, setConfirmDialog] = useState(null);
@@ -143,7 +144,7 @@ export function ReviewModule({ node }) {
     setCurrentImagePath(imagePath);
     setCurrentFileHash(null);
     setIsLoading(true);
-    setStatus('Detecting faces...');
+    setStatus(t('review.status.detecting'));
     setDetectedFaces([]);
     setCurrentFaceIndex(0);
     setPendingConfirmations([]);
@@ -162,7 +163,7 @@ export function ReviewModule({ node }) {
       const faces = result.faces || [];
       setDetectedFaces(faces);
       setCurrentFileHash(result.file_hash || null);
-      setStatus(`Found ${faces.length} faces (${result.processing_time_ms?.toFixed(0) || 0}ms)`);
+      setStatus(t('review.status.found', { count: faces.length, ms: result.processing_time_ms?.toFixed(0) || 0 }));
 
       emit('faces-detected', { faces, imagePath });
 
@@ -172,20 +173,20 @@ export function ReviewModule({ node }) {
         }, 100);
       } else {
         const fileName = imagePath.split('/').pop();
-        showToast(`No faces found in ${fileName}`, 'info');
+        showToast(t('review.toasts.noFacesFound', { fileName }), 'info');
       }
     } catch (err) {
       if (abortController.signal.aborted) {
-        setStatus('Detection cancelled');
+        setStatus(t('review.status.detectionCancelled'));
         return;
       }
       debugError('ReviewModule', 'Face detection failed:', err);
       if (err instanceof NetworkError) {
-        const msg = err.isOffline ? 'Backend unreachable' : err.message;
+        const msg = err.isOffline ? t('review.toasts.backendUnreachable') : err.message;
         showToast(msg, 'error');
-        setStatus('Connection error');
+        setStatus(t('review.status.connectionError'));
       } else {
-        setStatus('Detection failed');
+        setStatus(t('review.status.detectionFailed'));
       }
     } finally {
       if (detectAbortRef.current === abortController) {
@@ -491,7 +492,10 @@ export function ReviewModule({ node }) {
       });
     }
 
-    setStatus(`Accepted ${accepted}, ignored ${ignored}${skipped > 0 ? `, skipped ${skipped}` : ''}`);
+    setStatus(
+      t('review.status.accepted', { accepted, ignored }) +
+      (skipped > 0 ? t('review.status.acceptedSkippedSuffix', { skipped }) : '')
+    );
   }, [detectedFaces, currentImagePath, emit]);
 
   /**
@@ -538,7 +542,7 @@ export function ReviewModule({ node }) {
     if (pendingConfirmations.length === 0 && pendingIgnores.length === 0) return true;
 
     const totalChanges = pendingConfirmations.length + pendingIgnores.length;
-    setStatus(`Saving ${totalChanges} changes...`);
+    setStatus(t('review.status.saving', { count: totalChanges }));
 
     try {
       // Batch save: single request instead of N individual calls
@@ -550,11 +554,11 @@ export function ReviewModule({ node }) {
       setPendingConfirmations([]);
       setPendingIgnores([]);
       await loadPeopleNames();
-      setStatus(`Saved ${totalChanges} changes!`);
+      setStatus(t('review.status.saved', { count: totalChanges }));
       return true;
     } catch (err) {
       debugError('ReviewModule', 'Failed to save:', err);
-      setStatus('Error saving changes - review NOT marked complete');
+      setStatus(t('review.status.saveError'));
       return false;
     }
   }, [pendingConfirmations, pendingIgnores, api, loadPeopleNames]);
@@ -565,7 +569,7 @@ export function ReviewModule({ node }) {
   const discardChanges = useCallback(() => {
     if (pendingConfirmations.length === 0 && pendingIgnores.length === 0) return;
 
-    if (!confirm(`Discard ${pendingConfirmations.length + pendingIgnores.length} unsaved changes?`)) return;
+    if (!confirm(t('review.dialogs.discardConfirm', { count: pendingConfirmations.length + pendingIgnores.length }))) return;
 
     // Reset face states
     setDetectedFaces(prev => prev.map(face => {
@@ -577,7 +581,7 @@ export function ReviewModule({ node }) {
 
     setPendingConfirmations([]);
     setPendingIgnores([]);
-    setStatus('Changes discarded');
+    setStatus(t('review.status.changesDiscarded'));
   }, [pendingConfirmations.length, pendingIgnores.length]);
 
   /**
@@ -612,7 +616,7 @@ export function ReviewModule({ node }) {
       reviewedFaces
     });
 
-    setStatus('Image skipped');
+    setStatus(t('review.status.imageSkipped'));
   }, [currentImagePath, pendingConfirmations.length, pendingIgnores.length, saveAllChanges, buildReviewedFaces, markReviewComplete, emit, detectedFaces, currentFileHash]);
 
   /**
@@ -653,7 +657,7 @@ export function ReviewModule({ node }) {
       inputRefs.current[insertIndex]?.focus();
     }, 100);
 
-    setStatus('Manual face added - enter name');
+    setStatus(t('review.status.manualFaceAdded'));
   }, [currentImagePath, currentFaceIndex, detectedFaces.length, emit]);
 
   /**
@@ -730,7 +734,7 @@ export function ReviewModule({ node }) {
     const pendingCount = pendingConfirmations.length + pendingIgnores.length;
 
     if (pendingCount > 0) {
-      setStatus(`${reviewedCount}/${detectedFaces.length} reviewed | ${pendingCount} pending`);
+      setStatus(t('review.status.reviewProgress', { reviewed: reviewedCount, total: detectedFaces.length, pending: pendingCount }));
     }
   }, [detectedFaces, pendingConfirmations.length, pendingIgnores.length]);
 
@@ -887,8 +891,8 @@ export function ReviewModule({ node }) {
         const undone = undoLastAction();
         if (undone) {
           const msg = undone.type === 'confirm'
-            ? `Undo: ${undone.face.person_name || 'confirm'}`
-            : 'Undo: ignore';
+            ? t('review.toasts.undo', { label: undone.face.person_name || t('review.toasts.undoConfirmFallback') })
+            : t('review.toasts.undoIgnore');
           showToast(msg, 'info', 1500);
         }
         return;
@@ -899,7 +903,7 @@ export function ReviewModule({ node }) {
         e.preventDefault();
         if (isLoading) {
           cancelDetection();
-          showToast('Detection cancelled', 'info', 1500);
+          showToast(t('review.status.detectionCancelled'), 'info', 1500);
           return;
         }
         if (isInput) {
@@ -920,7 +924,7 @@ export function ReviewModule({ node }) {
       debug('ReviewModule', 'Skipping auto-detect for already-processed file:', imagePath);
       setCurrentImagePath(imagePath);
       setDetectedFaces([]);
-      setStatus('Already processed - click 🔄 to reprocess');
+      setStatus(t('review.status.alreadyProcessed'));
       return;
     }
     if (imagePath === currentImagePath && detectedFaces.length > 0) {
@@ -938,7 +942,7 @@ export function ReviewModule({ node }) {
     setCurrentImagePath(null);
     setDetectedFaces([]);
     setCurrentFaceIndex(-1);
-    setStatus('Waiting for image...');
+    setStatus(t('review.status.waitingForImage'));
   }, []));
 
   /**
@@ -956,8 +960,8 @@ export function ReviewModule({ node }) {
     const undone = undoLastAction();
     if (undone) {
       const msg = undone.type === 'confirm'
-        ? `Undo: ${undone.face.person_name || 'confirm'}`
-        : 'Undo: ignore';
+        ? t('review.toasts.undo', { label: undone.face.person_name || t('review.toasts.undoConfirmFallback') })
+        : t('review.toasts.undoIgnore');
       showToast(msg, 'info', 1500);
     }
   }, [undoLastAction, showToast]));
@@ -977,9 +981,9 @@ export function ReviewModule({ node }) {
 
       <div ref={gridRef} className="module-body face-grid">
         {isLoading ? (
-          <div className="loading">Detecting faces...</div>
+          <div className="loading">{t('review.status.detecting')}</div>
         ) : detectedFaces.length === 0 ? (
-          <div className="loading">No faces detected</div>
+          <div className="loading">{t('review.noFacesDetected')}</div>
         ) : (
           detectedFaces.map((face, index) => (
             <FaceCard
@@ -1075,25 +1079,25 @@ function ConfirmDialog({ type, topMatch, chosenName, onConfirm, onCancel }) {
         tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
       >
-        <h3>{isNameMismatch ? 'Confirm name change' : 'Confirm ignore'}</h3>
+        <h3>{isNameMismatch ? t('review.dialog.confirmNameChange') : t('review.dialog.confirmIgnore')}</h3>
         <div className="match-info">
-          Best match: <strong>{topMatch.name}</strong> ({topMatch.confidence}%)
+          {t('review.dialog.bestMatch')} <strong>{topMatch.name}</strong> ({topMatch.confidence}%)
         </div>
         <p>
           {isNameMismatch
-            ? `You chose "${chosenName}" instead. Are you sure?`
-            : 'You chose to ignore this face. Are you sure?'}
+            ? t('review.dialog.nameMismatch', { name: chosenName })
+            : t('review.dialog.ignoreConfirm')}
         </p>
         <div className="confirm-buttons">
           <button className="btn-cancel" onClick={onCancel}>
-            Cancel
+            {t('common.cancel')}
           </button>
           <button className="btn-confirm" onClick={onConfirm}>
-            Confirm
+            {t('common.confirm')}
           </button>
         </div>
         <div className="confirm-hint">
-          <kbd>Enter</kbd> confirms · <kbd>Esc</kbd> cancels
+          <kbd>Enter</kbd> {t('review.dialog.hintConfirms')} · <kbd>Esc</kbd> {t('review.dialog.hintCancels')}
         </div>
       </div>
     </div>
@@ -1185,7 +1189,7 @@ function FaceCard({ face, index, isActive, imagePath, people, cardRef, inputRef,
         ) : thumbnailUrl && !thumbnailError ? (
           <img
             src={thumbnailUrl}
-            alt={face.person_name || 'Unknown'}
+            alt={face.person_name || t('review.unknown')}
           />
         ) : (
           <Icon name="user" size={32} />
@@ -1247,7 +1251,7 @@ function FaceCard({ face, index, isActive, imagePath, people, cardRef, inputRef,
               ref={setInputRef}
               type="text"
               className={people.includes(inputValue) ? 'name-match' : ''}
-              placeholder="Person name..."
+              placeholder={t('review.placeholder')}
               value={inputValue}
               onChange={(e) => {
                 const val = e.target.value;
@@ -1315,10 +1319,10 @@ function FaceCard({ face, index, isActive, imagePath, people, cardRef, inputRef,
         ) : (
           <div
             className={`status-text ${face.is_rejected ? 'rejected' : 'confirmed'}`}
-            title="Double-click to undo"
+            title={t('review.undoTitle')}
           >
             {face.is_rejected ? (
-              <><Icon name="block" size={12} /> Ignored</>
+              <><Icon name="block" size={12} /> {t('review.ignoredBadge')}</>
             ) : (
               <><Icon name="check" size={12} /> {face.person_name}</>
             )}

--- a/frontend/src/renderer/components/StartupStatus.jsx
+++ b/frontend/src/renderer/components/StartupStatus.jsx
@@ -3,6 +3,7 @@ import { useBackend } from '../context/BackendContext.jsx';
 import { apiClient } from '../shared/api-client.js';
 import { debugError } from '../shared/debug.js';
 import { Icon } from './Icon.jsx';
+import { t } from '../../i18n/index.js';
 import './StartupStatus.css';
 
 const STATUS_ICONS = {
@@ -20,16 +21,16 @@ const STATE_CLASS = {
 };
 
 const COMPONENT_LABELS = {
-  backend: 'Backend',
-  database: 'Database',
-  mlModels: 'ML Models'
+  backend: t('startupStatus.labels.backend'),
+  database: t('startupStatus.labels.database'),
+  mlModels: t('startupStatus.labels.mlModels')
 };
 
 const INITIAL_STATUS = {
   items: {
-    backend: { state: 'loading', message: 'Connecting...' },
-    database: { state: 'pending', message: 'Waiting...' },
-    mlModels: { state: 'pending', message: 'Waiting...' }
+    backend: { state: 'loading', message: t('startupStatus.status.connecting') },
+    database: { state: 'pending', message: t('startupStatus.status.waiting') },
+    mlModels: { state: 'pending', message: t('startupStatus.status.waiting') }
   },
   allReady: false,
   hasError: false
@@ -79,7 +80,7 @@ export function StartupStatus() {
       ...prev,
       items: {
         ...prev.items,
-        backend: { state: 'ready', message: 'Connected' }
+        backend: { state: 'ready', message: t('startupStatus.status.connected') }
       }
     }));
 
@@ -98,15 +99,15 @@ export function StartupStatus() {
   );
   const startupDone = allReady || (!anyLoading && hasError);
   
-  let headerText = 'Starting...';
-  if (allReady) headerText = 'Ready';
-  else if (startupDone && hasError) headerText = 'Startup Error';
+  let headerText = t('startupStatus.status.starting');
+  if (allReady) headerText = t('startupStatus.status.ready');
+  else if (startupDone && hasError) headerText = t('startupStatus.status.error');
 
   return (
     <div 
       className={`startup-status ${fadeOut ? 'fade-out' : ''} ${allReady ? 'all-ready' : ''} ${startupDone && hasError ? 'has-error' : ''}`}
       onClick={handleDismiss}
-      title="Click to dismiss"
+      title={t('startupStatus.dismiss')}
     >
       <div className="startup-status-header">
         {headerText}


### PR DESCRIPTION
Final module group of the Swedish sweep — the review cluster + startup/shell leftovers, in one PR (separate catalog files). ReviewModule fully localized (dialogs, status messages, toasts, empty state, badges, tooltips — with interpolation and {one,other} plurals); ImageViewer, OriginalView, StartupStatus (backend→Servern), PlayerCount (Per match / Matchgap). No user-facing English display literals remain in these modules (verified). All keys resolve; 109 tests green, build clean. (Docs/ROADMAP consolidated in a follow-up PR.)