### PR TITLE
i18n: Swedish stragglers — api-client, workspace shell, main-process dialogs

### DIFF
--- a/frontend/src/i18n/sv/dialogs.js
+++ b/frontend/src/i18n/sv/dialogs.js
@@ -1,0 +1,23 @@
+// Swedish catalog namespace: dialogs
+// Main-process UI text: splash/startup status lines, native dialog messages,
+// and file-dialog filter names. "Servern" mirrors startupStatus for the backend.
+module.exports = {
+  "splash": {
+    "startingBackend": "Startar servern…",
+    "loadingInterface": "Laddar gränssnitt…",
+    "ready": "Klar!",
+    "initializingPython": "Initierar Python…",
+    "loadingModules": "Laddar Python-moduler…",
+    "startingApi": "Startar FastAPI…",
+    "startingWebServer": "Startar webbserver…",
+    "waitingForBackend": "Väntar på servern… ({current}/{total})"
+  },
+  "backendStartFailedSuggestion": "Kontrollera att Python är installerat och att ANSIKTEN_PYTHON pekar på rätt interpreter.",
+  "selectFolders": "Välj mapp(ar) för att lägga till alla bilder",
+  "filters": {
+    "images": "Bilder",
+    "rawImages": "RAW-bilder",
+    "allImages": "Alla bilder",
+    "allFiles": "Alla filer"
+  }
+};

--- a/frontend/src/i18n/sv/dialogs.js
+++ b/frontend/src/i18n/sv/dialogs.js
@@ -10,7 +10,8 @@ module.exports = {
     "loadingModules": "Laddar Python-moduler…",
     "startingApi": "Startar FastAPI…",
     "startingWebServer": "Startar webbserver…",
-    "waitingForBackend": "Väntar på servern… ({current}/{total})"
+    "waitingForBackend": "Väntar på servern… ({current}/{total})",
+    "serverReady": "Servern redo!"
   },
   "backendStartFailedSuggestion": "Kontrollera att Python är installerat och att ANSIKTEN_PYTHON pekar på rätt interpreter.",
   "selectFolders": "Välj mapp(ar) för att lägga till alla bilder",

--- a/frontend/src/i18n/sv/errors.js
+++ b/frontend/src/i18n/sv/errors.js
@@ -1,0 +1,9 @@
+// Swedish catalog namespace: errors
+// Network/request error messages surfaced to the UI via `error.message`
+// (e.g. StatisticsDashboard renders it as "Fel: <message>").
+module.exports = {
+  "noConnection": "Ingen nätverksanslutning",
+  "timeout": "Begäran tog för lång tid",
+  "unreachable": "Servern kan inte nås",
+  "unknown": "Okänt nätverksfel"
+};

--- a/frontend/src/i18n/sv/index.js
+++ b/frontend/src/i18n/sv/index.js
@@ -17,4 +17,7 @@ module.exports = {
   originalView: require('./originalView'),
   startupStatus: require('./startupStatus'),
   playerCount: require('./playerCount'),
+  errors: require('./errors'),
+  workspace: require('./workspace'),
+  dialogs: require('./dialogs'),
 };

--- a/frontend/src/i18n/sv/statistics.js
+++ b/frontend/src/i18n/sv/statistics.js
@@ -2,6 +2,7 @@
 module.exports = {
   "title": "Statistik",
   "ignored": "Ignorerade",
+  "errorPrefix": "Fel:",
 
   "autoRefresh": "Automatisk uppdatering",
   "refreshNow": "Uppdatera nu",

--- a/frontend/src/i18n/sv/workspace.js
+++ b/frontend/src/i18n/sv/workspace.js
@@ -1,0 +1,5 @@
+// Swedish catalog namespace: workspace
+module.exports = {
+  "loading": "Laddar arbetsyta…",
+  "unknownModule": "Okänd modul: {component}"
+};

--- a/frontend/src/main/backend-service.js
+++ b/frontend/src/main/backend-service.js
@@ -232,7 +232,7 @@ class BackendService {
       const isHealthy = await this.checkHealth();
       if (isHealthy) {
         console.log(`[BackendService] [${this._timestamp()}] Backend ready after ${i + 1} attempts`);
-        this._updateStatus('Backend redo!', 80);
+        this._updateStatus(t('dialogs.splash.serverReady'), 80);
         return;
       }
 

--- a/frontend/src/main/backend-service.js
+++ b/frontend/src/main/backend-service.js
@@ -15,6 +15,7 @@ const { app } = require('electron');
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
+const { t } = require('../i18n');
 
 const DEBUG = true;
 
@@ -218,7 +219,7 @@ class BackendService {
    */
   async waitForReady() {
     console.log(`[BackendService] [${this._timestamp()}] Starting health check polling...`);
-    this._updateStatus('Initializing Python...', 10);
+    this._updateStatus(t('dialogs.splash.initializingPython'), 10);
 
     await new Promise(resolve => setTimeout(resolve, 2000));
 
@@ -237,13 +238,13 @@ class BackendService {
 
       const progress = Math.min(10 + (i / this.maxRetries) * 60, 70);
       if (i === 0) {
-        this._updateStatus('Loading Python modules...', progress);
+        this._updateStatus(t('dialogs.splash.loadingModules'), progress);
       } else if (i === 3) {
-        this._updateStatus('Starting FastAPI...', progress);
+        this._updateStatus(t('dialogs.splash.startingApi'), progress);
       } else if (i === 6) {
-        this._updateStatus('Starting web server...', progress);
+        this._updateStatus(t('dialogs.splash.startingWebServer'), progress);
       } else if (i > 10) {
-        this._updateStatus(`Waiting for backend... (${i}/${this.maxRetries})`, progress);
+        this._updateStatus(t('dialogs.splash.waitingForBackend', { current: i, total: this.maxRetries }), progress);
       }
 
       if (DEBUG && i > 0 && i % 5 === 0) {

--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -12,6 +12,7 @@ const fs = require("fs");
 const os = require("os");
 const { BackendService } = require("./backend-service");
 const { createApplicationMenu } = require("./menu");
+const { t } = require("../i18n");
 const { parseCliArgs } = require("./cli-args");
 const { deriveRawToken, basenameMatchesToken } = require("./raw-match");
 
@@ -316,7 +317,7 @@ app.whenReady().then(async () => {
 
   // Show splash immediately
   createSplashWindow();
-  updateSplashStatus("Starting backend...");
+  updateSplashStatus(t("dialogs.splash.startingBackend"));
 
   // Start backend service
   try {
@@ -326,7 +327,7 @@ app.whenReady().then(async () => {
     };
     await backendService.start();
     console.log(`[Main] Backend ready at ${backendService.getUrl()}`);
-    updateSplashStatus("Loading interface...", 90);
+    updateSplashStatus(t("dialogs.splash.loadingInterface"), 90);
   } catch (err) {
     console.error("[Main] Failed to start backend:", err);
     
@@ -337,7 +338,7 @@ app.whenReady().then(async () => {
     const isPackaged = app.isPackaged;
     const suggestion = isPackaged
       ? "Försök installera om appen. Om problemet kvarstår, kontakta support."
-      : "Check that Python is installed and that ANSIKTEN_PYTHON points to the correct interpreter.";
+      : t("dialogs.backendStartFailedSuggestion");
     
     await dialog.showMessageBox({
       type: "error",
@@ -352,7 +353,7 @@ app.whenReady().then(async () => {
   }
 
   // Create workspace window
-  updateSplashStatus("Ready!", 100);
+  updateSplashStatus(t("dialogs.splash.ready"), 100);
   createWorkspaceWindow();
 
   // Close splash when main window is ready
@@ -493,10 +494,10 @@ ipcMain.handle("open-file-dialog", async () => {
     properties: ["openFile"],
     filters: [
       {
-        name: "Images",
+        name: t("dialogs.filters.images"),
         extensions: ["jpg", "jpeg", "png", "tiff", "nef", "cr2", "arw"],
       },
-      { name: "All Files", extensions: ["*"] },
+      { name: t("dialogs.filters.allFiles"), extensions: ["*"] },
     ],
   });
 
@@ -621,14 +622,14 @@ ipcMain.handle("open-multi-file-dialog", async () => {
     properties: ["openFile", "multiSelections"],
     filters: [
       {
-        name: "RAW Images",
+        name: t("dialogs.filters.rawImages"),
         extensions: ["nef", "NEF", "cr2", "CR2", "arw", "ARW"],
       },
       {
-        name: "All Images",
+        name: t("dialogs.filters.allImages"),
         extensions: ["jpg", "jpeg", "png", "tiff", "nef", "cr2", "arw"],
       },
-      { name: "All Files", extensions: ["*"] },
+      { name: t("dialogs.filters.allFiles"), extensions: ["*"] },
     ],
   });
 
@@ -646,7 +647,7 @@ ipcMain.handle("open-folder-dialog", async () => {
 
   const result = await dialog.showOpenDialog(mainWindow, {
     properties: ["openDirectory", "multiSelections"],
-    message: "Select folder(s) to add all images",
+    message: t("dialogs.selectFolders"),
   });
 
   if (result.canceled || !result.filePaths || result.filePaths.length === 0) {

--- a/frontend/src/renderer/components/StatisticsDashboard.jsx
+++ b/frontend/src/renderer/components/StatisticsDashboard.jsx
@@ -138,7 +138,7 @@ export function StatisticsDashboard() {
       </div>
 
       <div className="module-body stats-body">
-        {error && <div className="status-message error">Error: {error}</div>}
+        {error && <div className="status-message error">{t('statistics.errorPrefix')} {error}</div>}
 
         {/* Attempt Statistics Table */}
         {showAttemptStats && (

--- a/frontend/src/renderer/shared/api-client.js
+++ b/frontend/src/renderer/shared/api-client.js
@@ -6,6 +6,7 @@
  */
 
 import { debug, debugWarn, debugError } from './debug.js';
+import { t } from '../../i18n/index.js';
 
 export class NetworkError extends Error {
   constructor(message, { isOffline = false, isTimeout = false, statusCode = null, retryable = true } = {}) {
@@ -65,16 +66,16 @@ export class APIClient {
   _classifyError(err, response = null) {
     if (!navigator.onLine) {
       this._setOffline(true);
-      return new NetworkError('No network connection', { isOffline: true, retryable: true });
+      return new NetworkError(t('errors.noConnection'), { isOffline: true, retryable: true });
     }
 
     if (err.name === 'AbortError') {
-      return new NetworkError('Request timed out', { isTimeout: true, retryable: true });
+      return new NetworkError(t('errors.timeout'), { isTimeout: true, retryable: true });
     }
 
     if (err.name === 'TypeError' && err.message.includes('fetch')) {
       this._setOffline(true);
-      return new NetworkError('Backend unreachable', { isOffline: true, retryable: true });
+      return new NetworkError(t('errors.unreachable'), { isOffline: true, retryable: true });
     }
 
     if (response) {
@@ -83,7 +84,7 @@ export class APIClient {
       return new NetworkError(`HTTP ${statusCode}: ${response.statusText}`, { statusCode, retryable });
     }
 
-    return new NetworkError(err.message || 'Unknown network error', { retryable: false });
+    return new NetworkError(err.message || t('errors.unknown'), { retryable: false });
   }
 
   addConnectionListener(callback) {

--- a/frontend/src/renderer/splash.html
+++ b/frontend/src/renderer/splash.html
@@ -94,7 +94,7 @@
     <img src="../../assets/rainbowwaves.png" alt="Ansikten">
   </div>
   <h1>Ansikten</h1>
-  <p class="status" id="status">Starting...</p>
+  <p class="status" id="status">Startar…</p>
   <div class="progress-container">
     <div class="progress-bar" id="progress"></div>
   </div>

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -608,7 +608,7 @@ export function FlexLayoutWorkspace() {
     if (!ModuleComponent) {
       return (
         <div style={{ padding: 20, color: '#666' }}>
-          Unknown module: {component}
+          {t('workspace.unknownModule', { component })}
         </div>
       );
     }
@@ -728,7 +728,7 @@ export function FlexLayoutWorkspace() {
     // Create a placeholder tab in the new tabset
     const placeholderTab = {
       type: 'tab',
-      name: 'Image Viewer',
+      name: t('modules.image-viewer'),
       component: 'image-viewer',
       config: { moduleId: 'image-viewer' }
     };
@@ -1359,7 +1359,7 @@ export function FlexLayoutWorkspace() {
         height: '100%',
         color: '#666'
       }}>
-        Loading workspace...
+        {t('workspace.loading')}
       </div>
     );
   }


### PR DESCRIPTION
Final completeness pass of the Swedish sweep — the scattered strings the per-module PRs didn't cover:
- **api-client.js**: the `NetworkError` messages shown to the user (no connection / timeout / unreachable / unknown) → `errors.*`.
- **FlexLayoutWorkspace.jsx**: the "Unknown module" factory error, "Loading workspace…" state, and the `addTabset` placeholder tab (reuses `modules.image-viewer`) → `workspace.*`.
- **StatisticsDashboard.jsx**: the "Error:" prefix → `statistics.errorPrefix`.
- **main/index.js** + **main/backend-service.js** (CommonJS): splash statuses, the folder-dialog message, native file-dialog filter names, dev Python suggestion → `dialogs.*` (shared).
- **splash.html**: the pre-IPC "Starting…" placeholder (standalone, hardcoded Swedish).

~24 sites. Left as technical/non-display: `HTTP {code}: {statusText}` diagnostics, thrown/logged Error strings, the `CLI` acronym, the `'Ignored'` state sentinel. 109 tests green, build clean, main-process files `node --check` clean.

This completes the module/string migration. A consolidated ROADMAP/CHANGELOG update follows.