### PR TITLE
Roadmap: culling thumbnail/overview view (Lightroom-like)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,6 +32,14 @@ deliverables, DoD) för en prestandarelease.
 - [ ] Utveckla smidigare stöd för terminal-interaktion med backend (synkat med frontend).
 - [ ] **Modulgenvägar bör villkoras på aktiv tabset, inte bara synlighet** — globala tangentlyssnare (t.ex. ReviewModule som bekräftar ansikte på `Enter`) gatar idag på `node.isVisible()`. I en delad layout med flera synliga paneler fångar då en *synlig men inaktiv* panel tangenter som hör till den aktiva. CullingModule försvarar sig redan (Enter-genväg på document i capture-fas + aktiv-tabset-gate + `stopImmediatePropagation`), men det generella mönstret kvarstår för övriga moduler. ReviewModule m.fl. bör gatas på aktiv tabset. **Varning:** måste inte bryta Reviews normala flöde där man klickar i bildvisaren och sedan trycker tangent (då blir bildvisarens tabset aktiv) — kräver genomtänkt fokus-/aktiv-modell, egen PR.
 - [ ] **Arbetsflödes-layoutpresets** — spara flerfönsterkonfigurationer per uppgift (t.ex. NEF-culling = fillista vänster + maximal preview höger). De flesta vyer är single-instance: öppna inte flera, skifta fokus till befintlig.
+- [ ] **Gallra spelare — thumbnailvy (översiktsläge, Lightroom-likt)** — ett rutnät/contact-sheet över den filtrerade fillistan som ett *översiktsläge* vid sidan av dagens enkelbildsvy, med Lightroom-liknande rörelse mellan lägena. Interaktion:
+  - **Dubbelklick på en thumbnail** → enkelbildsvy (dagens default) för den bilden.
+  - **Esc i enkelbildsvy, när inget redigeras** → tillbaka till översiktsvyn (thumbs). Esc behåller sin nuvarande roll när något *är* under redigering (avbryt pending namn-bockning, stäng kontextmeny osv.) — övergången till thumbs sker bara när inget redigeringstillstånd är öppet.
+  - Klick på **spelarnamn** (stats-kolumnen) är lägesberoende:
+    - *I thumbsvy:* **enkelklick** → *highlighta* (markera visuellt) de thumbnails som innehåller spelaren, utan att filtrera bort övriga; **dubbelklick** → filtrera thumbs till endast spelarens bilder.
+    - *I enkelbildsvy:* **enkelklick** → som idag, visa endast spelarens bilder.
+
+  Genomförbart additivt: highlight per spelare kan härledas i klienten ur filnamnen (`namesInBasename` i `culling-names.js`), så ingen ny backend-data krävs för markeringen. Kräver dock: thumbnail-generering/-cache (nedskalad JPEG-avkodning; NEF/raw via befintlig NEF→JPG-pipeline), en rutnätskomponent med markerings-/selektionsmodell, och att cull-tangenterna (`x`/Delete, `Cmd+⌫`, undo) fungerar på fokuserad/markerad thumbnail. Läges-övergångarna måste väva in i den befintliga capture-fas-Esc-hanteringen (som redan gatar på aktiv tabset och pending-tillstånd). Läget bör persistas som del av vy-tillståndet. Egen, större PR.
 - [ ] **Docs-uppdatering (dev-docs)** — användardokumenten och ROADMAP är genomgångna (2026-07-02). Kvar: dev-docs (`docs/dev/architecture.md`, `docs/dev/onboarding.md` m.fl.) kan ha kvar engelska modulnamn/inaktuella referenser efter i18n-svepet och rebranden.
 
 ### Lång sikt


### PR DESCRIPTION
Adds a ROADMAP item (Mellan sikt) capturing a proposed **thumbnail/grid overview mode** for Gallra spelare (culling), inspired by Lightroom's grid view. Not implemented here — roadmap note only.

Captured interaction model:
- Grid/contact-sheet as an *overview mode* alongside today's single-image view.
- **Double-click a thumbnail** → single-image view (current default) for that image.
- **Esc in single-image view, when nothing is being edited** → back to the overview grid. Esc keeps its current edit-time role (discard pending name toggles, close context menu) — the mode transition only fires when no edit state is open.
- Clicking a **player name** (stats column) is mode-dependent:
  - *Grid:* single-click → highlight thumbs containing that player (no filtering); double-click → filter thumbs to only that player.
  - *Single-image:* single-click → filter to that player (as today).

Feasibility note included: per-player highlight is derivable client-side from filenames (`namesInBasename`), so no new backend data is needed for highlighting; the lift is thumbnail generation/caching, a grid component with a selection model, cull-keys on the focused/selected thumb, and weaving the mode transitions into the existing capture-phase Esc handling. Flagged as its own larger PR.