### PR TITLE
(server) Fix startup preload broken by management-store migration

### DIFF
--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -40,8 +40,6 @@ async def lifespan(app: FastAPI):
         """Sync function for thread pool - loads database and rotates logs"""
         from faceid_db import rotate_logs
 
-        from .services.management_service import get_management_service
-
         # Rotate logs on startup to prevent unbounded growth
         rotate_logs()
 
@@ -53,8 +51,10 @@ async def lifespan(app: FastAPI):
         except Exception:
             logger.warning("Trash retention purge on startup failed", exc_info=True)
 
-        svc = get_management_service()
-        return len(svc.known_faces)
+        from .services.db_store import get_db_store
+
+        # Warm the shared store (loads the DB) and report the people count.
+        return get_db_store().read(lambda known, ignored, hardneg, processed: len(known))
 
     async def preload_database():
         t0 = time.perf_counter()


### PR DESCRIPTION
PR #141 removed ManagementService.known_faces (migrated onto FaceDBStore), but api/server.py's startup preload still read it — the preload raised AttributeError, /health reported database:error and startup was degraded (store still lazy-loaded, endpoints worked). The preload now warms the shared store directly via get_db_store().read(...) returning the people count. Found during #143 verification; own PR per one-PR-per-thing.

Testing: ruff clean; pytest 216 passed; live boot shows database: ready — 105 persons (0.08s), previously error.