### PR TITLE
(landing) Restore compact step buttons; clarify workflow vs tools

### DIFF
--- a/frontend/src/i18n/sv/startupLanding.js
+++ b/frontend/src/i18n/sv/startupLanding.js
@@ -1,7 +1,8 @@
 // Swedish catalog namespace: startupLanding
 module.exports = {
   "title": "Kom igång",
-  "subtitle": "Välj ett steg i arbetsflödet.",
+  "subtitle": "Följ stegen i ordning, eller öppna ett verktyg direkt.",
+  "workflow": "Arbetsflöde",
   "tools": "Verktyg",
   "importCardHint": "Sätt i ett minneskort för att importera"
 };

--- a/frontend/src/renderer/components/StartupLanding.css
+++ b/frontend/src/renderer/components/StartupLanding.css
@@ -70,12 +70,24 @@
   width: 100%;
 }
 
-/* Extends the shared Button primitive (variant="primary"); layout tweaks only. */
+/* Extends the shared Button primitive; layout tweaks only. Size (font/padding)
+   comes from the primitive: this component historically declared font-lg +
+   thick padding, but the legacy .btn-action rules used to win the cascade so
+   the rule was dormant — B7's bundle-order change woke it up and everything
+   grew. Keep the primitive's compact size. */
 .startup-landing-step {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: var(--space-sm);
-  padding: var(--space-md);
-  font-size: var(--font-lg);
+  width: 100%;
+}
+
+/* Ordinal for the workflow steps — the first group IS a sequence. */
+.startup-landing-step .step-ordinal {
+  font-family: var(--font-mono);
+  color: inherit;
+  opacity: 0.75;
+  min-width: 1.2em;
+  text-align: right;
 }

--- a/frontend/src/renderer/components/StartupLanding.jsx
+++ b/frontend/src/renderer/components/StartupLanding.jsx
@@ -65,18 +65,21 @@ export function StartupLanding({ onOpenModule }) {
     return () => clearInterval(id);
   }, [checkVolumes]);
 
-  const renderStep = (step) => {
+  // Workflow steps are the page's main actions (primary, numbered — they form
+  // a sequence); tools are supporting views (secondary, unnumbered).
+  const renderStep = (step, ordinal) => {
     const disabled = step.requiresCard && !cardPresent;
     return (
       <Button
         key={step.moduleId}
-        variant="primary"
+        variant={ordinal != null ? 'primary' : 'secondary'}
         className="startup-landing-step"
         disabled={disabled}
         title={disabled ? t('startupLanding.importCardHint') : undefined}
         onClick={() => onOpenModule(step.moduleId)}
       >
-        <Icon name={step.icon} size={20} />
+        {ordinal != null && <span className="step-ordinal" aria-hidden="true">{ordinal}.</span>}
+        <Icon name={step.icon} size={16} />
         <span>{t(`modules.${step.moduleId}`)}</span>
       </Button>
     );
@@ -87,10 +90,11 @@ export function StartupLanding({ onOpenModule }) {
       <div className="startup-landing-card">
         <h1 className="startup-landing-title">{t('startupLanding.title')}</h1>
         <p className="startup-landing-subtitle">{t('startupLanding.subtitle')}</p>
-        <div className="startup-landing-steps">{STEPS.map(renderStep)}</div>
+        <div className="startup-landing-divider">{t('startupLanding.workflow')}</div>
+        <div className="startup-landing-steps">{STEPS.map((s, i) => renderStep(s, i + 1))}</div>
 
         <div className="startup-landing-divider">{t('startupLanding.tools')}</div>
-        <div className="startup-landing-steps">{TOOLS.map(renderStep)}</div>
+        <div className="startup-landing-steps">{TOOLS.map((s) => renderStep(s))}</div>
       </div>
     </div>
   );

--- a/frontend/tests/StartupLanding.test.jsx
+++ b/frontend/tests/StartupLanding.test.jsx
@@ -21,11 +21,11 @@ describe('StartupLanding', () => {
     const buttons = await screen.findAllByRole('button');
     expect(buttons.map((b) => b.textContent)).toEqual([
       // Workflow steps (unchanged order)
-      'Importera',
-      'Byt namn',
-      'Granska ansikten',
-      'Räkna spelare',
-      'Gallra spelare',
+      '1.Importera',
+      '2.Byt namn',
+      '3.Granska ansikten',
+      '4.Räkna spelare',
+      '5.Gallra spelare',
       // Tools (remaining views), appended
       'Databashantering',
       'Förfina ansikten',


### PR DESCRIPTION
User-reported regression on the startup landing page after the B7 migration, plus a UX clarification.

**Regression (text/buttons grew, page scrolls):** `.startup-landing-step` has always declared `font-size: var(--font-lg)` + thick padding, but the rule was dormant — legacy `.btn-action` (theme.css) was bundled after module CSS and won the cascade, so the buttons rendered compact. B7's switch to the shared Button flipped the bundle order (shared.css now comes first), waking the dormant rule. Fix: the component keeps layout-only tweaks; size comes from the primitive again (compact, no scrolling).

**Workflow vs tools made visible:** the first five entries are the workflow steps in order (Importera → Byt namn → Granska → Räkna spelare → Gallra); the rest are supporting views. The page never showed that logic. Now: an "Arbetsflöde" heading + numbered steps (the content genuinely is a sequence) rendered as primary; tools stay under "Verktyg" as secondary. Also resolves the twelve-identical-primary-buttons violation of the one-primary rule. Subtitle updated to match.

## Verification
- 473/473 tests (the landing order test synced to the numbered labels), lint clean, build OK; bundle inspected — the step class no longer declares font-size/padding.
