### PR TITLE
(release) Prepare v1.4.1 changelog and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-08
+
+### Fixed
+- **Landningssidan: stegknapparna växte efter B7 och tvingade fram skroll.** `.startup-landing-step` har alltid deklarerat `font-size: var(--font-lg)` + tjock padding, men regeln var vilande — legacy `.btn-action` (theme.css, buntad efter modul-CSS) vann kaskaden. B7:s byte till delade `<Button>` flippade buntordningen och väckte regeln. Den vilande storleksregeln är borttagen; primitivens kompakta storlek gäller och allt ryms utan skroll.
+
+### Changed
+- **Landningssidan visar nu arbetsflödeslogiken.** De fem första posterna är arbetsflödets steg i ordning — nu under rubriken "Arbetsflöde", numrerade 1–5 och som primärknappar; stödvyerna ligger kvar under "Verktyg" som secondary. Undertexten uppdaterad ("Följ stegen i ordning, eller öppna ett verktyg direkt."). Ordinalen är dold för skärmläsare (knappnamnet förblir rent, t.ex. "Importera").
+
 ## [1.4.0] - 2026-07-08
 
 ### Fixed

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -138,7 +138,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Ansikten Backend API",
     description="Face detection and annotation API for Ansikten image viewer",
-    version="1.4.0",
+    version="1.4.1",
     lifespan=lifespan
 )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ansikten-backend"
-version = "1.4.0"
+version = "1.4.1"
 description = "Face recognition backend for event photography"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -24,7 +24,7 @@ Check backend status and component readiness.
 {
   "status": "ok",
   "service": "ansikten-backend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "components": {
     "backend": { "state": "ready", "message": "Connected" },
     "database": { "state": "ready", "message": "42 persons" },
@@ -38,7 +38,7 @@ Check backend status and component readiness.
 {
   "status": "starting",
   "service": "ansikten-backend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "components": {
     "backend": { "state": "ready", "message": "Connected" },
     "database": { "state": "loading", "message": "Läser in..." },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ansikten",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ansikten",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "GPL-3.0",
       "dependencies": {
         "flexlayout-react": "^0.8.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ansikten",
   "productName": "Ansikten",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Face detection and annotation tool for image review",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Patch release: the startup-landing regression fix + workflow/tools clarification (#185), which missed its changelog entry — added here under [1.4.1].

Bumps all four version sites (package.json, package-lock, pyproject.toml, api/server.py) plus the /health doc examples — the complete set from the v1.4.0 release review.