### PR TITLE
Release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-08
+
+### Fixed
+- **Landningssidan: stegknapparna växte efter B7 och tvingade fram skroll.** `.startup-landing-step` har alltid deklarerat `font-size: var(--font-lg)` + tjock padding, men regeln var vilande — legacy `.btn-action` (theme.css, buntad efter modul-CSS) vann kaskaden. B7:s byte till delade `<Button>` flippade buntordningen och väckte regeln. Den vilande storleksregeln är borttagen; primitivens kompakta storlek gäller och allt ryms utan skroll.
+
+### Changed
+- **Landningssidan visar nu arbetsflödeslogiken.** De fem första posterna är arbetsflödets steg i ordning — nu under rubriken "Arbetsflöde", numrerade 1–5 och som primärknappar; stödvyerna ligger kvar under "Verktyg" som secondary. Undertexten uppdaterad ("Följ stegen i ordning, eller öppna ett verktyg direkt."). Ordinalen är dold för skärmläsare (knappnamnet förblir rent, t.ex. "Importera").
+
 ## [1.4.0] - 2026-07-08
 
 ### Fixed

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -138,7 +138,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Ansikten Backend API",
     description="Face detection and annotation API for Ansikten image viewer",
-    version="1.4.0",
+    version="1.4.1",
     lifespan=lifespan
 )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ansikten-backend"
-version = "1.4.0"
+version = "1.4.1"
 description = "Face recognition backend for event photography"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -24,7 +24,7 @@ Check backend status and component readiness.
 {
   "status": "ok",
   "service": "ansikten-backend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "components": {
     "backend": { "state": "ready", "message": "Connected" },
     "database": { "state": "ready", "message": "42 persons" },
@@ -38,7 +38,7 @@ Check backend status and component readiness.
 {
   "status": "starting",
   "service": "ansikten-backend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "components": {
     "backend": { "state": "ready", "message": "Connected" },
     "database": { "state": "loading", "message": "Läser in..." },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ansikten",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ansikten",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "GPL-3.0",
       "dependencies": {
         "flexlayout-react": "^0.8.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ansikten",
   "productName": "Ansikten",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Face detection and annotation tool for image review",
   "main": "main.js",
   "scripts": {

--- a/frontend/src/i18n/sv/startupLanding.js
+++ b/frontend/src/i18n/sv/startupLanding.js
@@ -1,7 +1,8 @@
 // Swedish catalog namespace: startupLanding
 module.exports = {
   "title": "Kom igång",
-  "subtitle": "Välj ett steg i arbetsflödet.",
+  "subtitle": "Följ stegen i ordning, eller öppna ett verktyg direkt.",
+  "workflow": "Arbetsflöde",
   "tools": "Verktyg",
   "importCardHint": "Sätt i ett minneskort för att importera"
 };

--- a/frontend/src/renderer/components/StartupLanding.css
+++ b/frontend/src/renderer/components/StartupLanding.css
@@ -70,12 +70,24 @@
   width: 100%;
 }
 
-/* Extends the shared Button primitive (variant="primary"); layout tweaks only. */
+/* Extends the shared Button primitive; layout tweaks only. Size (font/padding)
+   comes from the primitive: this component historically declared font-lg +
+   thick padding, but the legacy .btn-action rules used to win the cascade so
+   the rule was dormant — B7's bundle-order change woke it up and everything
+   grew. Keep the primitive's compact size. */
 .startup-landing-step {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: var(--space-sm);
-  padding: var(--space-md);
-  font-size: var(--font-lg);
+  width: 100%;
+}
+
+/* Ordinal for the workflow steps — the first group IS a sequence. */
+.startup-landing-step .step-ordinal {
+  font-family: var(--font-mono);
+  color: inherit;
+  opacity: 0.75;
+  min-width: 1.2em;
+  text-align: right;
 }

--- a/frontend/src/renderer/components/StartupLanding.jsx
+++ b/frontend/src/renderer/components/StartupLanding.jsx
@@ -65,18 +65,21 @@ export function StartupLanding({ onOpenModule }) {
     return () => clearInterval(id);
   }, [checkVolumes]);
 
-  const renderStep = (step) => {
+  // Workflow steps are the page's main actions (primary, numbered — they form
+  // a sequence); tools are supporting views (secondary, unnumbered).
+  const renderStep = (step, ordinal) => {
     const disabled = step.requiresCard && !cardPresent;
     return (
       <Button
         key={step.moduleId}
-        variant="primary"
+        variant={ordinal != null ? 'primary' : 'secondary'}
         className="startup-landing-step"
         disabled={disabled}
         title={disabled ? t('startupLanding.importCardHint') : undefined}
         onClick={() => onOpenModule(step.moduleId)}
       >
-        <Icon name={step.icon} size={20} />
+        {ordinal != null && <span className="step-ordinal" aria-hidden="true">{ordinal}.</span>}
+        <Icon name={step.icon} size={16} />
         <span>{t(`modules.${step.moduleId}`)}</span>
       </Button>
     );
@@ -87,10 +90,11 @@ export function StartupLanding({ onOpenModule }) {
       <div className="startup-landing-card">
         <h1 className="startup-landing-title">{t('startupLanding.title')}</h1>
         <p className="startup-landing-subtitle">{t('startupLanding.subtitle')}</p>
-        <div className="startup-landing-steps">{STEPS.map(renderStep)}</div>
+        <div className="startup-landing-divider">{t('startupLanding.workflow')}</div>
+        <div className="startup-landing-steps">{STEPS.map((s, i) => renderStep(s, i + 1))}</div>
 
         <div className="startup-landing-divider">{t('startupLanding.tools')}</div>
-        <div className="startup-landing-steps">{TOOLS.map(renderStep)}</div>
+        <div className="startup-landing-steps">{TOOLS.map((s) => renderStep(s))}</div>
       </div>
     </div>
   );

--- a/frontend/tests/StartupLanding.test.jsx
+++ b/frontend/tests/StartupLanding.test.jsx
@@ -21,11 +21,11 @@ describe('StartupLanding', () => {
     const buttons = await screen.findAllByRole('button');
     expect(buttons.map((b) => b.textContent)).toEqual([
       // Workflow steps (unchanged order)
-      'Importera',
-      'Byt namn',
-      'Granska ansikten',
-      'Räkna spelare',
-      'Gallra spelare',
+      '1.Importera',
+      '2.Byt namn',
+      '3.Granska ansikten',
+      '4.Räkna spelare',
+      '5.Gallra spelare',
       // Tools (remaining views), appended
       'Databashantering',
       'Förfina ansikten',


### PR DESCRIPTION
Patch release: startup-landing size regression fix + workflow/tools clarification (#185), with the retroactive changelog entry and full version bumps (#186). Tag `v1.4.1` follows on the merge commit.