### PR TITLE
Fix ruff import-lint findings (unblocks backend CI)

### DIFF
--- a/backend/benchmarks/baseline_check.py
+++ b/backend/benchmarks/baseline_check.py
@@ -26,7 +26,8 @@ import sys
 
 import numpy as np
 
-from . import cache, config as cfg
+from . import cache
+from . import config as cfg
 from .dataset import MATCHED, build_dataset, load_bgr
 from .db_access import DEFAULT_DB_PATH, load_db_records
 
@@ -96,7 +97,7 @@ def run(records, index, detector, recognition, *, force=False):
 
 
 def main(argv=None) -> int:
-    from .models.buffalo import BuffaloDetector, BuffaloRecognition, DEFAULT_DET_SIZE
+    from .models.buffalo import DEFAULT_DET_SIZE, BuffaloDetector, BuffaloRecognition
     from .resolve import build_index
 
     ap = argparse.ArgumentParser(description=__doc__)

--- a/backend/benchmarks/bench_providers.py
+++ b/backend/benchmarks/bench_providers.py
@@ -169,9 +169,9 @@ def run(root: Path, num: int, seed: int) -> dict:
 
     coreml_available = "CoreMLExecutionProvider" in _available_providers()
 
-    print(f"Building CPU pipeline ...", file=sys.stderr)
+    print("Building CPU pipeline ...", file=sys.stderr)
     cpu = Pipeline(CPU_PROVIDERS)
-    print(f"Building CoreML pipeline ...", file=sys.stderr)
+    print("Building CoreML pipeline ...", file=sys.stderr)
     coreml = Pipeline(COREML_PROVIDERS)
 
     # --- warm-up (excluded from timing): first CoreML run compiles the model ---

--- a/backend/benchmarks/dataset.py
+++ b/backend/benchmarks/dataset.py
@@ -26,7 +26,8 @@ from pathlib import Path
 
 import numpy as np
 
-from . import cache, config as cfg
+from . import cache
+from . import config as cfg
 from .db_access import DEFAULT_DB_PATH, FaceRecord, load_db_records
 from .resolver import SourceIndex, sha1_file  # noqa: F401  (sha1_file handy for callers)
 
@@ -127,9 +128,10 @@ def build_dataset(
     rows: list[DatasetFace] = []
     for sha1, recs in by_hash.items():
         paths = h2p.get(sha1, [])
-        db_id_for = lambda r: r.encoding_hash or cache.deterministic_face_id(
-            sha1, r.bbox_xyxy or (0, 0, 0, 0)
-        )
+        def db_id_for(r):
+            return r.encoding_hash or cache.deterministic_face_id(
+                sha1, r.bbox_xyxy or (0, 0, 0, 0)
+            )
 
         if not paths:
             for r in recs:
@@ -218,7 +220,7 @@ def main(argv=None) -> int:
     import argparse
     import sys
 
-    from .models.buffalo import BuffaloDetector, DEFAULT_DET_SIZE
+    from .models.buffalo import DEFAULT_DET_SIZE, BuffaloDetector
     from .resolve import build_index
 
     ap = argparse.ArgumentParser(description=__doc__)

--- a/backend/benchmarks/detect_compare.py
+++ b/backend/benchmarks/detect_compare.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
 
 from . import cache
 from . import config as cfg

--- a/backend/tests/test_benchmark_resolver.py
+++ b/backend/tests/test_benchmark_resolver.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 import hashlib
 import json
 
-import pytest
-
 from benchmarks.db_access import (
     FaceRecord,
     face_counts,
-    records_from_db,
     recorded_hash_map,
+    records_from_db,
 )
 from benchmarks.resolver import SourceIndex, resolve_hashes, sha1_file
 from benchmarks.strata import (

--- a/backend/tests/test_benchmark_yoloface.py
+++ b/backend/tests/test_benchmark_yoloface.py
@@ -6,8 +6,6 @@ integration test that needs a downloaded ONNX is guarded by a file check.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 

--- a/backend/tests/test_det_size.py
+++ b/backend/tests/test_det_size.py
@@ -10,9 +10,8 @@ Covers:
 import pytest
 
 import face_backends
-from face_backends import create_backend, normalize_det_size
 from core.config import DEFAULT_CONFIG
-
+from face_backends import create_backend, normalize_det_size
 
 # --------------------------------------------------------------------------
 # normalize_det_size

--- a/backend/tests/test_provider_logging.py
+++ b/backend/tests/test_provider_logging.py
@@ -14,7 +14,6 @@ import platform
 
 import pytest
 
-import face_backends
 from face_backends import InsightFaceBackend
 
 


### PR DESCRIPTION
## Background

CI:s backend-jobb kör ruff med senaste versionen (lokalt reproducerat med ruff 0.15.20), som nu flaggar 13 pre-existerande fel på `dev`. Det gör backend-CI rött för alla PR:er tills de åtgärdas.

## Vad som fixas

`ruff check backend/` gick från 13 fel → 0. Fördelningen visade sig vara bredare än bara import-sortering:

| Regel | Antal | Åtgärd |
|-------|-------|--------|
| I001 (unsorted-imports) | 6 | Auto-fix (import-sortering) |
| F401 (unused-import) | 4 | Auto-fix (borttagning av oanvända importer) |
| F541 (f-string utan platshållare) | 2 | Auto-fix (`f"..."` → `"..."`) |
| E731 (lambda-assignment) | 1 | Manuell: `db_id_for` lambda → nested `def` (beteendebevarande) |

Det F401-fall som pekats ut som "hidden fix" (`import face_backends` i `tests/test_provider_logging.py`) verifierades vara genuint död: modulnamnet refereras aldrig som `face_backends.x`, och `from face_backends import InsightFaceBackend` behålls, så eventuell import-sidoeffekt bevaras.

## Verifiering

- `ruff check backend/` → **All checks passed!** (exit 0)
- `pytest` → **420 passed, 1 skipped**
- Diffen innehåller endast import-sortering/borttagning, borttagna redundanta `f`-prefix och en beteendebevarande lambda→def-konvertering. Inga beteendeförändringar.