### PR TITLE
Import → rename hand-off, robust exiftool resolution, surfaced error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+### Added
+- **Direkt hand-off Importera → Byt namn.** Efter en klar import visar importpanelen en knapp **"Döp om filer…"** som öppnar namnbytesmodulen med den importerade målmappen förvald. Namnbytesmodulen förväljer också målmappen från senast använda importdestination vid öppning. Ingen automatisk växling — allt är opt-in.
+
 ### Fixed
 - **Robust exiftool-upplösning.** NEF-namnbyte och EXIF-baserade steg hittar nu `exiftool` även när appen startats från GUI (Electron på macOS ärver en PATH utan `/opt/homebrew/bin`). `exiftool` slås upp via PATH med fallback till Homebrew-katalogerna, och backend-processen får dessa kataloger i PATH.
 - **Tydligare felmeddelanden från backend.** HTTP-fel visar nu FastAPI:s `detail`-text (t.ex. "exiftool krävs men hittades inte i PATH") i stället för en naken statustext.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ### Fixed
 - **Robust exiftool-upplösning.** NEF-namnbyte och EXIF-baserade steg hittar nu `exiftool` även när appen startats från GUI (Electron på macOS ärver en PATH utan `/opt/homebrew/bin`). `exiftool` slås upp via PATH med fallback till Homebrew-katalogerna, och backend-processen får dessa kataloger i PATH.
+- **Tydligare felmeddelanden från backend.** HTTP-fel visar nu FastAPI:s `detail`-text (t.ex. "exiftool krävs men hittades inte i PATH") i stället för en naken statustext.
 
 ## [1.5.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+### Fixed
+- **Robust exiftool-upplösning.** NEF-namnbyte och EXIF-baserade steg hittar nu `exiftool` även när appen startats från GUI (Electron på macOS ärver en PATH utan `/opt/homebrew/bin`). `exiftool` slås upp via PATH med fallback till Homebrew-katalogerna, och backend-processen får dessa kataloger i PATH.
+
 ## [1.5.0] - 2026-07-10
 
 ### Docs

--- a/backend/api/services/rename_service.py
+++ b/backend/api/services/rename_service.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from api.services.db_store import get_db_store
+from core.exiftool import find_exiftool
 from core.files import SUPPORTED_EXTENSIONS
 from core.naming import normalize_name
 from faceid_db import (
@@ -114,7 +115,7 @@ def extract_exif_datetime(file_path: Path) -> Optional[datetime]:
         try:
             import subprocess
             result = subprocess.run(
-                ['exiftool', '-DateTimeOriginal', '-s', '-s', '-s', str(file_path)],
+                [find_exiftool(), '-DateTimeOriginal', '-s', '-s', '-s', str(file_path)],
                 capture_output=True, text=True, timeout=5
             )
             if result.returncode == 0 and result.stdout.strip():

--- a/backend/core/exiftool.py
+++ b/backend/core/exiftool.py
@@ -1,0 +1,38 @@
+"""Locate the ``exiftool`` binary robustly.
+
+A GUI-launched Electron app on macOS inherits a minimal PATH that usually lacks
+``/opt/homebrew/bin`` (Apple Silicon Homebrew) and ``/usr/local/bin`` (Intel
+Homebrew), so a bare ``exiftool`` invocation raises FileNotFoundError even when
+the tool is installed. Resolving the absolute path here lets every exiftool
+caller work regardless of how the process was started.
+"""
+
+import os
+import shutil
+
+# Common install locations to probe when exiftool is not on PATH.
+_FALLBACK_PATHS = (
+    "/opt/homebrew/bin/exiftool",
+    "/usr/local/bin/exiftool",
+)
+
+
+def find_exiftool() -> str:
+    """Return an absolute path to a runnable ``exiftool``.
+
+    Tries PATH first (``shutil.which``), then well-known Homebrew locations.
+
+    Raises:
+        FileNotFoundError: if no runnable exiftool can be found.
+    """
+    found = shutil.which("exiftool")
+    if found:
+        return found
+
+    for candidate in _FALLBACK_PATHS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+
+    raise FileNotFoundError(
+        "exiftool not found on PATH or in /opt/homebrew/bin, /usr/local/bin"
+    )

--- a/backend/filer2mappar.py
+++ b/backend/filer2mappar.py
@@ -19,6 +19,8 @@ from datetime import datetime
 from glob import glob
 from pathlib import Path
 
+from core.exiftool import find_exiftool
+
 DATE_PATTERN = re.compile(r'^(\d{6})_')
 
 
@@ -75,16 +77,15 @@ def extract_dates_from_exif(files: list[Path]) -> dict[Path, str]:
     if not files:
         return {}
 
-    cmd = [
-        "exiftool", "-q", "-q", "-m",
-        "-if", "defined $CreateDate",
-        "-d", "%y%m%d",
-        "-p", "$CreateDate|$FilePath",
-        "--",
-        *[str(f) for f in files]
-    ]
-
     try:
+        cmd = [
+            find_exiftool(), "-q", "-q", "-m",
+            "-if", "defined $CreateDate",
+            "-d", "%y%m%d",
+            "-p", "$CreateDate|$FilePath",
+            "--",
+            *[str(f) for f in files]
+        ]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
     except FileNotFoundError:
         print("FEL: exiftool krävs för --exif-date", file=sys.stderr)

--- a/backend/rename_nef.py
+++ b/backend/rename_nef.py
@@ -15,6 +15,8 @@ from collections import defaultdict
 from glob import glob
 from pathlib import Path
 
+from core.exiftool import find_exiftool
+
 # Simple logging setup for this standalone script
 logging.basicConfig(
     level=logging.WARNING,
@@ -28,7 +30,7 @@ def get_exif_data(files: list[Path]) -> list[tuple[str, int, Path]]:
         return []
     
     cmd = [
-        "exiftool", "-q", "-q", "-m",
+        find_exiftool(), "-q", "-q", "-m",
         "-if", "defined $CreateDate",
         "-d", "%y%m%d_%H%M%S",
         "-p", "$CreateDate|${SubSecTimeOriginal;$_||=0}|$FilePath",

--- a/backend/tests/test_exiftool.py
+++ b/backend/tests/test_exiftool.py
@@ -1,0 +1,35 @@
+"""Tests for core.exiftool.find_exiftool path resolution."""
+
+import pytest
+
+import core.exiftool as exiftool_mod
+from core.exiftool import find_exiftool
+
+
+def test_returns_path_from_which(monkeypatch):
+    """A PATH hit via shutil.which is used verbatim."""
+    monkeypatch.setattr(exiftool_mod.shutil, "which", lambda _: "/usr/bin/exiftool")
+    assert find_exiftool() == "/usr/bin/exiftool"
+
+
+def test_falls_back_to_known_location(monkeypatch):
+    """With no PATH hit, a runnable well-known location is returned."""
+    monkeypatch.setattr(exiftool_mod.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        exiftool_mod, "_FALLBACK_PATHS", ("/opt/homebrew/bin/exiftool",)
+    )
+    monkeypatch.setattr(
+        exiftool_mod.os.path, "isfile", lambda p: p == "/opt/homebrew/bin/exiftool"
+    )
+    monkeypatch.setattr(exiftool_mod.os, "access", lambda p, mode: True)
+
+    assert find_exiftool() == "/opt/homebrew/bin/exiftool"
+
+
+def test_missing_raises_file_not_found(monkeypatch):
+    """No PATH hit and no existing fallback → FileNotFoundError."""
+    monkeypatch.setattr(exiftool_mod.shutil, "which", lambda _: None)
+    monkeypatch.setattr(exiftool_mod.os.path, "isfile", lambda p: False)
+
+    with pytest.raises(FileNotFoundError):
+        find_exiftool()

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -202,10 +202,11 @@ Skriptet kräver att appen är installerad i `/Applications/Ansikten.app` (macOS
 1. Öppna **Importera** (`Cmd+Shift+I`). Modulen listar isatta minneskort med antal NEF.
 2. Välj kort, målmapp (kom ihåg senaste), samt Flytta/Kopiera och om kortet ska matas ut.
 3. Klicka **Importera** — en förloppsindikator visas; kortet matas ut efter felfri överföring.
+4. När importen är klar visas knappen **"Döp om filer…"** i resultatet — den öppnar **Byt namn** med den importerade mappen redan ifylld (nästa steg).
 
 ### 0b. Byt namn på NEF (valfritt)
 
-1. Öppna **Byt namn** (`Cmd+Shift+B`), välj mappen (ev. glob `DSC*`).
+1. Öppna **Byt namn** (`Cmd+Shift+B`), välj mappen (ev. glob `DSC*`). Målmappen förväljs från senaste importdestination.
 2. **Förhandsgranska** visar `DSC… → YYMMDD_HHMMSS.NEF` (dubbletter får `-NN`; filer utan CreateDate hoppas över).
 3. **Byt namn** utför; befintliga målnamn skrivs aldrig över.
 

--- a/frontend/src/i18n/sv/import.js
+++ b/frontend/src/i18n/sv/import.js
@@ -22,6 +22,7 @@ module.exports = {
   "skippedSuffix": ", {count} överhoppade",
   "ejected": "Kortet utmatat ✓",
   "notEjected": "Kortet ej utmatat",
+  "openRename": "Döp om filer…",
   "errorsSummary": "{count} fel",
   "doneToast": {
     "one": "{count} NEF överförd",

--- a/frontend/src/main/backend-service.js
+++ b/frontend/src/main/backend-service.js
@@ -20,6 +20,28 @@ const { t } = require('../i18n');
 // Verbose backend logging is opt-in via ANSIKTEN_DEBUG=1 (off in production).
 const DEBUG = process.env.ANSIKTEN_DEBUG === '1';
 
+// Homebrew bin directories that hold CLI tools the backend shells out to
+// (notably exiftool). A GUI-launched app inherits a minimal PATH that usually
+// omits these, so a bare `exiftool` would fail with ENOENT.
+const EXTRA_BIN_PATHS = ['/opt/homebrew/bin', '/usr/local/bin'];
+
+/**
+ * Append well-known Homebrew bin dirs to a PATH string on macOS/Linux, without
+ * overriding entries that are already present. Windows PATH is returned as-is.
+ * @param {string} basePath - The PATH value to augment (may be undefined).
+ * @returns {string} The augmented PATH.
+ */
+function augmentPath(basePath) {
+  const original = basePath || '';
+  if (process.platform === 'win32') return original;
+
+  const existing = original.split(path.delimiter).filter(Boolean);
+  const missing = EXTRA_BIN_PATHS.filter((p) => !existing.includes(p));
+  if (missing.length === 0) return original;
+
+  return [...existing, ...missing].join(path.delimiter);
+}
+
 class BackendService {
   constructor() {
     this.process = null;
@@ -83,6 +105,7 @@ class BackendService {
         cwd: backendDir,
         env: {
           ...process.env,
+          PATH: augmentPath(process.env.PATH),
           ANSIKTEN_PORT: this.port.toString()
         }
       };
@@ -142,6 +165,7 @@ class BackendService {
         cwd: backendDir,
         env: {
           ...process.env,
+          PATH: augmentPath(process.env.PATH),
           PYTHONPATH: backendDir,
           ANSIKTEN_PORT: this.port.toString(),
           ANSIKTEN_LOG_LEVEL: logLevel

--- a/frontend/src/renderer/components/ImportModule.css
+++ b/frontend/src/renderer/components/ImportModule.css
@@ -89,3 +89,7 @@
   margin: 4px 0 0 16px;
   padding: 0;
 }
+
+.import-next {
+  margin-top: 6px;
+}

--- a/frontend/src/renderer/components/ImportModule.jsx
+++ b/frontend/src/renderer/components/ImportModule.jsx
@@ -9,7 +9,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useBackend } from '../context/BackendContext.jsx';
 import { useWebSocket } from '../hooks/useWebSocket.js';
-import { useModuleEvent } from '../hooks/useModuleEvent.js';
+import { useModuleEvent, useEmitEvent } from '../hooks/useModuleEvent.js';
 import { useToast } from '../context/ToastContext.jsx';
 import { preferences } from '../workspace/preferences.js';
 import { Button, Alert, ProgressBar } from './shared';
@@ -22,6 +22,7 @@ const isMac = navigator.platform.toLowerCase().includes('mac');
 export function ImportModule() {
   const { api } = useBackend();
   const showToast = useToast();
+  const emit = useEmitEvent();
 
   const [volumes, setVolumes] = useState([]);
   const [selectedMount, setSelectedMount] = useState('');
@@ -37,6 +38,10 @@ export function ImportModule() {
   const [progressLabel, setProgressLabel] = useState('');
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  // Destination the last completed import actually wrote to. Captured at run
+  // time so the "Döp om filer…" hand-off targets that folder even if the field
+  // is edited afterwards.
+  const [importedDest, setImportedDest] = useState('');
 
   const loadVolumes = useCallback(async () => {
     setLoadingVolumes(true);
@@ -110,14 +115,16 @@ export function ImportModule() {
     setError(null);
     setProgress(0);
     setProgressLabel('');
+    const usedDestination = destination.trim();
     try {
       const res = await api.post('/api/v1/import/run', {
         volume_mount: selectedMount,
-        destination: destination.trim(),
+        destination: usedDestination,
         mode,
         eject,
       });
       setResult(res);
+      setImportedDest(usedDestination);
       // Transient receipt of the completed transfer; the result panel below
       // keeps the persistent, inspectable breakdown (skipped/errors/eject).
       const count = res.transferred?.length ?? 0;
@@ -132,6 +139,12 @@ export function ImportModule() {
       setProgress(null);
     }
   }, [api, selectedMount, destination, mode, eject, loadVolumes, showToast]);
+
+  // Hand the just-imported folder to the rename step (opt-in; never auto-opened).
+  const openRename = useCallback(() => {
+    if (!importedDest) return;
+    emit('open-rename-nef', { roots: [importedDest] });
+  }, [emit, importedDest]);
 
   const selected = volumes.find((v) => v.mount === selectedMount);
   const canRun = !running && !!selectedMount && destination.trim() !== '';
@@ -239,6 +252,13 @@ export function ImportModule() {
                 <summary>{t('import.errorsSummary', { count: result.errors.length })}</summary>
                 <ul>{result.errors.map((e, i) => <li key={i}>{e.path}: {e.error}</li>)}</ul>
               </details>
+            )}
+            {importedDest && (
+              <div className="import-next">
+                <Button variant="secondary" size="sm" onClick={openRename}>
+                  {t('import.openRename')}
+                </Button>
+              </div>
             )}
           </div>
         )}

--- a/frontend/src/renderer/components/RenameNefModule.jsx
+++ b/frontend/src/renderer/components/RenameNefModule.jsx
@@ -9,6 +9,8 @@
 import React, { useState, useCallback } from 'react';
 import { useBackend } from '../context/BackendContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
+import { useModuleEvent } from '../hooks/useModuleEvent.js';
+import { preferences } from '../workspace/preferences.js';
 import { Button, IconButton, Alert, EmptyState } from './shared';
 import { t } from '../../i18n/index.js';
 import './RenameNefModule.css';
@@ -17,7 +19,13 @@ export function RenameNefModule() {
   const { api } = useBackend();
   const showToast = useToast();
 
-  const [roots, setRoots] = useState([]);
+  // Pre-fill with the import destination so the common "import then rename"
+  // flow starts pointed at the right folder. Backend file_resolver expands ~,
+  // so a stored ~-path is fine to pass through. Missing preference → empty.
+  const [roots, setRoots] = useState(() => {
+    const dest = preferences.get('import.destination');
+    return dest ? [dest] : [];
+  });
   const [glob, setGlob] = useState('');
   const [preview, setPreview] = useState(null);
   const [result, setResult] = useState(null);
@@ -29,6 +37,18 @@ export function RenameNefModule() {
     globs: glob.trim() ? [glob.trim()] : [],
     recursive: true,
   }), [roots, glob]);
+
+  // Hand-off from Import ("Döp om filer…"): union the imported folder(s) with
+  // any already-listed roots and clear stale preview/result state.
+  useModuleEvent('rename-nef-load', (data) => {
+    const incoming = data?.roots || [];
+    if (incoming.length) {
+      setRoots((r) => Array.from(new Set([...r, ...incoming])));
+    }
+    setPreview(null);
+    setResult(null);
+    setError(null);
+  }, []);
 
   const addFolder = useCallback(async () => {
     try {

--- a/frontend/src/renderer/components/RenameNefModule.jsx
+++ b/frontend/src/renderer/components/RenameNefModule.jsx
@@ -38,14 +38,17 @@ export function RenameNefModule() {
     recursive: true,
   }), [roots, glob]);
 
-  // Hand-off from Import ("Döp om filer…"): REPLACE the roots with the imported
-  // folder(s), not union. The hand-off means "rename what I just imported"; the
-  // pre-filled default root can be stale (the import destination field may have
-  // been edited after the import), so unioning could rename in the wrong folder.
+  // Hand-off from Import ("Döp om filer…"): scope the module strictly to the
+  // imported folder(s). REPLACE roots (not union) — the pre-filled default root
+  // can be stale (the import destination field may have been edited after the
+  // import). Also CLEAR any leftover glob: params() forwards it and the backend
+  // resolver unions glob matches with the root scan, so a stale pattern like
+  // /old/*.NEF would pull in files outside the just-imported folder.
   useModuleEvent('rename-nef-load', (data) => {
     const incoming = data?.roots || [];
     if (incoming.length) {
       setRoots(Array.from(new Set(incoming)));
+      setGlob('');
     }
     setPreview(null);
     setResult(null);

--- a/frontend/src/renderer/components/RenameNefModule.jsx
+++ b/frontend/src/renderer/components/RenameNefModule.jsx
@@ -38,12 +38,14 @@ export function RenameNefModule() {
     recursive: true,
   }), [roots, glob]);
 
-  // Hand-off from Import ("Döp om filer…"): union the imported folder(s) with
-  // any already-listed roots and clear stale preview/result state.
+  // Hand-off from Import ("Döp om filer…"): REPLACE the roots with the imported
+  // folder(s), not union. The hand-off means "rename what I just imported"; the
+  // pre-filled default root can be stale (the import destination field may have
+  // been edited after the import), so unioning could rename in the wrong folder.
   useModuleEvent('rename-nef-load', (data) => {
     const incoming = data?.roots || [];
     if (incoming.length) {
-      setRoots((r) => Array.from(new Set([...r, ...incoming])));
+      setRoots(Array.from(new Set(incoming)));
     }
     setPreview(null);
     setResult(null);

--- a/frontend/src/renderer/shared/api-client.js
+++ b/frontend/src/renderer/shared/api-client.js
@@ -63,17 +63,17 @@ export class APIClient {
     }
   }
 
-  _classifyError(err, response = null) {
+  async _classifyError(err, response = null) {
     if (!navigator.onLine) {
       this._setOffline(true);
       return new NetworkError(t('errors.noConnection'), { isOffline: true, retryable: true });
     }
 
-    if (err.name === 'AbortError') {
+    if (err?.name === 'AbortError') {
       return new NetworkError(t('errors.timeout'), { isTimeout: true, retryable: true });
     }
 
-    if (err.name === 'TypeError' && err.message.includes('fetch')) {
+    if (err?.name === 'TypeError' && err.message.includes('fetch')) {
       this._setOffline(true);
       return new NetworkError(t('errors.unreachable'), { isOffline: true, retryable: true });
     }
@@ -81,10 +81,36 @@ export class APIClient {
     if (response) {
       const statusCode = response.status;
       const retryable = statusCode >= 500 || statusCode === 429;
-      return new NetworkError(`HTTP ${statusCode}: ${response.statusText}`, { statusCode, retryable });
+      // Prefer the backend's JSON error detail (FastAPI `{"detail": "..."}`)
+      // over the bare status text so users see the real cause, e.g.
+      // "HTTP 400: exiftool krävs men hittades inte i PATH." The response body
+      // can only be read once; this is the sole reader on the error path (the
+      // success path returns before classification runs).
+      const detail = await this._readErrorDetail(response);
+      const message = detail || response.statusText;
+      return new NetworkError(`HTTP ${statusCode}: ${message}`, { statusCode, retryable });
     }
 
-    return new NetworkError(err.message || t('errors.unknown'), { retryable: false });
+    return new NetworkError(err?.message || t('errors.unknown'), { retryable: false });
+  }
+
+  /**
+   * Read a FastAPI-style error detail string from a response body.
+   * Returns null for non-JSON bodies, a non-string `detail`, or a body that
+   * cannot be read (e.g. already consumed) — callers fall back to status text.
+   * @param {Response} response
+   * @returns {Promise<string|null>}
+   */
+  async _readErrorDetail(response) {
+    try {
+      const body = await response.json();
+      if (body && typeof body.detail === 'string') {
+        return body.detail;
+      }
+    } catch {
+      // Non-JSON or unreadable body → caller falls back to statusText.
+    }
+    return null;
   }
 
   addConnectionListener(callback) {
@@ -158,7 +184,7 @@ export class APIClient {
       });
 
       if (!response.ok) {
-        throw this._classifyError(null, response);
+        throw await this._classifyError(null, response);
       }
 
       return await response.json();
@@ -167,7 +193,7 @@ export class APIClient {
         debugError('Backend', `GET ${path} failed:`, err.message);
         throw err;
       }
-      const classified = this._classifyError(err, response);
+      const classified = await this._classifyError(err, response);
       debugError('Backend', `GET ${path} failed:`, classified.message);
       throw classified;
     }
@@ -193,7 +219,7 @@ export class APIClient {
       });
 
       if (!response.ok) {
-        throw this._classifyError(null, response);
+        throw await this._classifyError(null, response);
       }
 
       return await response.json();
@@ -202,7 +228,7 @@ export class APIClient {
         debugError('Backend', `POST ${path} failed:`, err.message);
         throw err;
       }
-      const classified = this._classifyError(err, response);
+      const classified = await this._classifyError(err, response);
       debugError('Backend', `POST ${path} failed:`, classified.message);
       throw classified;
     }
@@ -502,7 +528,7 @@ export class APIClient {
       });
 
       if (!response.ok) {
-        throw this._classifyError(null, response);
+        throw await this._classifyError(null, response);
       }
 
       return await response.json();
@@ -511,7 +537,7 @@ export class APIClient {
         debugError('Backend', 'DELETE /api/v1/preprocessing/cache failed:', err.message);
         throw err;
       }
-      const classified = this._classifyError(err, response);
+      const classified = await this._classifyError(err, response);
       debugError('Backend', 'DELETE /api/v1/preprocessing/cache failed:', classified.message);
       throw classified;
     }

--- a/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/FlexLayoutWorkspace.jsx
@@ -606,6 +606,17 @@ export function FlexLayoutWorkspace() {
     };
     const offOpenImport = window.ansiktenAPI.on('open-import', handleOpenImport);
 
+    // In-app hand-off from Import → Rename-NEF ("Döp om filer…"). Unlike the
+    // CLI hand-offs above this is a renderer moduleAPI event (no IPC): open/focus
+    // the rename-nef module, then pass it the just-imported folder once it has
+    // subscribed. waitForListeners guards the cold-start race on first open.
+    const handleOpenRenameNef = async ({ roots }) => {
+      openModule('rename-nef');
+      await moduleAPI.waitForListeners('rename-nef-load', 2000);
+      moduleAPI.emit('rename-nef-load', { roots });
+    };
+    const offOpenRenameNef = moduleAPI.on('open-rename-nef', handleOpenRenameNef);
+
     // Track which files have unsaved Review changes so the culling hand-off
     // above won't close Review and discard them.
     const offReviewDirty = moduleAPI.on('review-dirty', ({ imagePath, dirty }) => {
@@ -626,6 +637,7 @@ export function FlexLayoutWorkspace() {
       offMenuCommand?.();
       offOpenCulling?.();
       offOpenImport?.();
+      offOpenRenameNef?.();
       offReviewDirty?.();
     };
   }, [ready, loadLayout, addTabset, removeEmptyTabset, openModule, closeModule, moduleAPI, moveToNewTabset]);

--- a/frontend/tests/apiClient.test.js
+++ b/frontend/tests/apiClient.test.js
@@ -122,6 +122,69 @@ describe('APIClient._fetchWithTimeout', () => {
   });
 });
 
+// A non-ok response whose JSON body carries a FastAPI-style { detail }.
+function detailErrorFetch(status, detail, statusText = 'Error') {
+  return vi.fn(() => Promise.resolve({
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.resolve({ detail })
+  }));
+}
+
+// A non-ok response whose body is not JSON (json() rejects).
+function nonJsonErrorFetch(status, statusText = 'Bad Request') {
+  return vi.fn(() => Promise.resolve({
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.reject(new Error('Unexpected token < in JSON'))
+  }));
+}
+
+describe('APIClient error detail extraction', () => {
+  let client;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    client = new APIClient('http://127.0.0.1:9999');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('uses the backend JSON detail string as the error message', async () => {
+    global.fetch = detailErrorFetch(400, 'exiftool krävs men hittades inte i PATH.');
+
+    const err = await client.post('/api/v1/rename-nef/preview', {}).catch(e => e);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err.statusCode).toBe(400);
+    expect(err.retryable).toBe(false);
+    expect(err.message).toBe('HTTP 400: exiftool krävs men hittades inte i PATH.');
+  });
+
+  it('falls back to statusText when the body is not JSON', async () => {
+    global.fetch = nonJsonErrorFetch(400, 'Bad Request');
+
+    const err = await client.get('/api/v1/anything').catch(e => e);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toBe('HTTP 400: Bad Request');
+  });
+
+  it('falls back to statusText when detail is not a string', async () => {
+    // FastAPI validation errors put an array under `detail`; only strings are used.
+    global.fetch = detailErrorFetch(422, [{ msg: 'x' }], 'Unprocessable Entity');
+
+    const err = await client.post('/api/v1/anything', {}).catch(e => e);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err.statusCode).toBe(422);
+    expect(err.message).toBe('HTTP 422: Unprocessable Entity');
+  });
+});
+
 describe('APIClient.clearCache', () => {
   let client;
   const originalFetch = global.fetch;


### PR DESCRIPTION
## Summary

Dogfooding the import → rename flow surfaced three issues; this PR fixes all of them.

### Fixed
- **Rename failed with "HTTP 400: Bad Request"** when the app was GUI-launched: macOS Electron inherits a minimal PATH without `/opt/homebrew/bin`, so the bare `exiftool` invocation raised `FileNotFoundError`. exiftool is now resolved via `shutil.which` with Homebrew fallbacks (`backend/core/exiftool.py`), used by `rename_nef.py`, `filer2mappar.py` and `rename_service.py`. The Electron backend spawn also appends Homebrew bin dirs to PATH (both dev and packaged spawn paths).
- **Error messages discarded the backend's explanation**: `api-client.js` now reads FastAPI's JSON `detail` on non-ok responses, so users see e.g. "HTTP 400: exiftool krävs men hittades inte i PATH." instead of "HTTP 400: Bad Request". Falls back to statusText for non-JSON bodies and non-string details.

### Added
- **"Döp om filer…" button** in the import result panel: opens the Rename-NEF module with the just-imported destination folder pre-loaded (opt-in, no auto-switch). Hand-off follows the existing openModule + waitForListeners + emit pattern.
- **Folder pre-fill in Rename-NEF**: the module now defaults its root to the last used import destination (`import.destination` preference).

## Tests
- New: `backend/tests/test_exiftool.py` (which-hit, fallback, missing → FileNotFoundError); apiClient detail-extraction tests (detail string, non-JSON body, non-string detail).
- `cd backend && pytest`: 423 passed, 1 skipped. `cd frontend && npm test`: 476 passed. `npm run build:workspace`: OK.

## Docs
- CHANGELOG `[Unreleased]` updated; workspace guide mentions the new hand-off button and pre-filled folder.