### PR TITLE
Shared working-folder anchor for the pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 ## [Unreleased]
 
 ### Added
+- **Arbetsmapp-ankare (osynligt i UI ännu).** En tunn gemensam pekare (`shared/workingFolder.js`) håller reda på "det aktuella eventets mapp" genom pipelinen: importsteget sätter ankaret till den importerade målmappen och namnbytessteget avancerar det efter ett klart namnbyte. Namnbytesmodulen förväljer nu roots från ankaret först (sedan `import.destination`-prefen, sedan tomt). Allt är opt-in — ankaret är en pekare som förfyller defaults, aldrig en auto-laddning; det överlever Cmd+R (sessionStorage) men nollas vid appomstart så förra veckans event aldrig erbjuds. De tre arbetsmängderna (filkö, scan-scope, destination) och `import.destination`-prefen lämnas orörda. Synligt UI kommer i en senare etapp.
 - **Direkt hand-off Importera → Byt namn.** Efter en klar import visar importpanelen en knapp **"Döp om filer…"** som öppnar namnbytesmodulen med den importerade målmappen förvald. Namnbytesmodulen förväljer också målmappen från senast använda importdestination vid öppning. Ingen automatisk växling — allt är opt-in.
 
 ### Changed

--- a/frontend/src/renderer/components/ImportModule.jsx
+++ b/frontend/src/renderer/components/ImportModule.jsx
@@ -12,6 +12,7 @@ import { useWebSocket } from '../hooks/useWebSocket.js';
 import { useModuleEvent, useEmitEvent } from '../hooks/useModuleEvent.js';
 import { useToast } from '../context/ToastContext.jsx';
 import { preferences } from '../workspace/preferences.js';
+import { setWorkingFolder } from '../shared/workingFolder.js';
 import { Button, Alert, ProgressBar } from './shared';
 import { t } from '../../i18n/index.js';
 import './ImportModule.css';
@@ -125,6 +126,9 @@ export function ImportModule() {
       });
       setResult(res);
       setImportedDest(usedDestination);
+      // Anchor the pipeline on the just-imported folder so the rename step can
+      // pre-fill from it (opt-in; the anchor is a pointer, not an auto-load).
+      setWorkingFolder({ roots: [usedDestination], step: 'import' });
       // Transient receipt of the completed transfer; the result panel below
       // keeps the persistent, inspectable breakdown (skipped/errors/eject).
       const count = res.transferred?.length ?? 0;

--- a/frontend/src/renderer/components/RenameNefModule.jsx
+++ b/frontend/src/renderer/components/RenameNefModule.jsx
@@ -12,6 +12,7 @@ import { useToast } from '../context/ToastContext.jsx';
 import { useModuleEvent } from '../hooks/useModuleEvent.js';
 import { useWebSocket } from '../hooks/useWebSocket.js';
 import { preferences } from '../workspace/preferences.js';
+import { getWorkingFolder, setWorkingFolder } from '../shared/workingFolder.js';
 import { Button, IconButton, Alert, EmptyState, ProgressBar } from './shared';
 import { t } from '../../i18n/index.js';
 import './RenameNefModule.css';
@@ -20,10 +21,13 @@ export function RenameNefModule() {
   const { api } = useBackend();
   const showToast = useToast();
 
-  // Pre-fill with the import destination so the common "import then rename"
-  // flow starts pointed at the right folder. Backend file_resolver expands ~,
-  // so a stored ~-path is fine to pass through. Missing preference → empty.
+  // Pre-fill so the common "import then rename" flow starts pointed at the
+  // right folder. Prefer the working-folder anchor (set by the just-run import),
+  // then fall back to the import.destination preference, then empty. Backend
+  // file_resolver expands ~, so a stored ~-path is fine to pass through.
   const [roots, setRoots] = useState(() => {
+    const anchored = getWorkingFolder()?.roots;
+    if (anchored && anchored.length) return [...anchored];
     const dest = preferences.get('import.destination');
     return dest ? [dest] : [];
   });
@@ -58,6 +62,9 @@ export function RenameNefModule() {
     if (incoming.length) {
       setRoots(Array.from(new Set(incoming)));
       setGlob('');
+      // The import hand-off is authoritative about the event folder; keep the
+      // anchor in step with it (still tagged 'import' — rename hasn't run yet).
+      setWorkingFolder({ roots: incoming, step: 'import' });
     }
     setPreview(null);
     setResult(null);
@@ -100,6 +107,9 @@ export function RenameNefModule() {
       const data = await api.post('/api/v1/rename-nef/execute', params());
       setResult(data);
       setPreview(null);
+      // Rename finished on these folders — advance the anchor to 'rename' so the
+      // next step (review/count) can pre-fill from the same event folder.
+      if (roots.length) setWorkingFolder({ roots, step: 'rename' });
       // Transient receipt; the result panel keeps the persistent breakdown.
       const count = data.renamed?.length ?? 0;
       showToast(t('renameNef.doneToast', { count }), {
@@ -110,7 +120,7 @@ export function RenameNefModule() {
     } finally {
       setBusy(false);
     }
-  }, [api, params, showToast]);
+  }, [api, params, roots, showToast]);
 
   const canPreview = !busy && (roots.length > 0 || glob.trim() !== '');
   const canExecute = !busy && preview && preview.to_rename > 0;

--- a/frontend/src/renderer/shared/workingFolder.js
+++ b/frontend/src/renderer/shared/workingFolder.js
@@ -1,0 +1,90 @@
+// Shared "working folder" anchor — a single pointer to the folder of the event
+// currently being worked on. The pipeline (Import → Rename → Review → Count →
+// Culling) has three independent working sets (file queue, scan scope,
+// destination), but they tend to point at the same event folder. This anchor
+// lets a later step pre-fill from where an earlier step left off, without
+// merging those working sets. It is a pointer only — no queue, no scanning.
+//
+// Adoption is always opt-in: a step reads the anchor to seed a default, never
+// to auto-load. `step` records which pipeline step last set the anchor
+// ('import' | 'rename' | …) so a UI (arriving in a later stage) can label it.
+//
+// Backed by sessionStorage (like scanScope.js): the anchor survives a renderer
+// reload (Cmd+R) but clears when the app quits. sessionStorage is deliberately
+// chosen over localStorage so last week's event is never offered on a fresh
+// launch — the anchor only ever points at an event touched this session.
+
+const STORAGE_KEY = 'ansikten.workingFolder';
+
+let current = null;
+// A reload re-imports this module (current = null); hydrate from sessionStorage
+// on first read so an adopting step sees the pre-reload anchor.
+let hydrated = false;
+const subscribers = new Set();
+
+function hydrate() {
+  if (hydrated) return;
+  hydrated = true;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) current = JSON.parse(raw);
+  } catch {
+    /* ignore — unreadable/parse error just means no restored anchor */
+  }
+}
+
+/**
+ * The current working-folder anchor, or null if none set this session.
+ * Shape: { roots: string[], step: string | null, ts: number }.
+ */
+export function getWorkingFolder() {
+  hydrate();
+  return current;
+}
+
+/**
+ * Set the anchor. Stamps `ts` itself. Pass { roots, step }; a shallow copy of
+ * roots is stored. Subscribers are notified.
+ */
+export function setWorkingFolder({ roots = [], step = null } = {}) {
+  hydrated = true; // an explicit set supersedes any not-yet-hydrated value
+  current = { roots: [...roots], step, ts: Date.now() };
+  persist();
+  notify();
+}
+
+/** Clear the anchor. Subscribers are notified. */
+export function clearWorkingFolder() {
+  hydrated = true;
+  current = null;
+  persist();
+  notify();
+}
+
+/**
+ * Subscribe to anchor changes. Returns an unsubscribe function.
+ * The callback receives the current anchor (or null).
+ */
+export function subscribeWorkingFolder(cb) {
+  subscribers.add(cb);
+  return () => subscribers.delete(cb);
+}
+
+function persist() {
+  try {
+    if (current) sessionStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+    else sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore — storage unavailable/full just falls back to in-memory only */
+  }
+}
+
+function notify() {
+  for (const cb of subscribers) {
+    try {
+      cb(current);
+    } catch {
+      /* a broken subscriber must not stop the others */
+    }
+  }
+}

--- a/frontend/tests/workingFolder.test.js
+++ b/frontend/tests/workingFolder.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getWorkingFolder,
+  setWorkingFolder,
+  clearWorkingFolder,
+  subscribeWorkingFolder,
+} from '../src/renderer/shared/workingFolder.js';
+
+const STORAGE_KEY = 'ansikten.workingFolder';
+
+describe('workingFolder store', () => {
+  beforeEach(() => clearWorkingFolder());
+
+  it('starts empty', () => {
+    expect(getWorkingFolder()).toBeNull();
+  });
+
+  it('set stamps ts and stores roots + step', () => {
+    const before = Date.now();
+    setWorkingFolder({ roots: ['/photos/event'], step: 'import' });
+    const wf = getWorkingFolder();
+    expect(wf.roots).toEqual(['/photos/event']);
+    expect(wf.step).toBe('import');
+    expect(typeof wf.ts).toBe('number');
+    expect(wf.ts).toBeGreaterThanOrEqual(before);
+  });
+
+  it('stores a copy of roots (later mutation of the source does not leak in)', () => {
+    const src = ['/a'];
+    setWorkingFolder({ roots: src, step: 'rename' });
+    src.push('/b');
+    expect(getWorkingFolder().roots).toEqual(['/a']);
+  });
+
+  it('defaults roots to [] and step to null', () => {
+    setWorkingFolder({});
+    const wf = getWorkingFolder();
+    expect(wf.roots).toEqual([]);
+    expect(wf.step).toBeNull();
+  });
+
+  it('clearWorkingFolder resets to null', () => {
+    setWorkingFolder({ roots: ['/a'], step: 'import' });
+    clearWorkingFolder();
+    expect(getWorkingFolder()).toBeNull();
+  });
+});
+
+describe('workingFolder subscription', () => {
+  beforeEach(() => clearWorkingFolder());
+
+  it('notifies subscribers on set and clear', () => {
+    const cb = vi.fn();
+    subscribeWorkingFolder(cb);
+    setWorkingFolder({ roots: ['/a'], step: 'import' });
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].roots).toEqual(['/a']);
+    clearWorkingFolder();
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb.mock.calls[1][0]).toBeNull();
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const cb = vi.fn();
+    const unsub = subscribeWorkingFolder(cb);
+    unsub();
+    setWorkingFolder({ roots: ['/a'], step: 'import' });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('a broken subscriber does not stop the others', () => {
+    const good = vi.fn();
+    subscribeWorkingFolder(() => { throw new Error('boom'); });
+    subscribeWorkingFolder(good);
+    setWorkingFolder({ roots: ['/a'], step: 'import' });
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('workingFolder persistence (survives a renderer reload)', () => {
+  beforeEach(() => clearWorkingFolder());
+
+  it('setWorkingFolder writes the anchor to sessionStorage', () => {
+    setWorkingFolder({ roots: ['/a'], step: 'import' });
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw)).toMatchObject({ roots: ['/a'], step: 'import' });
+  });
+
+  it('clearWorkingFolder removes the sessionStorage key', () => {
+    setWorkingFolder({ roots: ['/a'], step: 'import' });
+    clearWorkingFolder();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('a re-imported module (reload) hydrates the persisted anchor on first read', async () => {
+    setWorkingFolder({ roots: ['/photos'], step: 'rename' });
+    vi.resetModules();
+    const fresh = await import('../src/renderer/shared/workingFolder.js');
+    expect(fresh.getWorkingFolder()).toMatchObject({ roots: ['/photos'], step: 'rename' });
+  });
+
+  it('a re-imported module with nothing persisted stays empty', async () => {
+    clearWorkingFolder();
+    vi.resetModules();
+    const fresh = await import('../src/renderer/shared/workingFolder.js');
+    expect(fresh.getWorkingFolder()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Stage 1 of the pipeline-coherence work. The app's three working sets (face file queue, culling scan scope, import destination) stay as they are — this adds a thin shared **working-folder anchor**: a single pointer to "the folder of the event being worked on".

### Added
- `frontend/src/renderer/shared/workingFolder.js`: `{ roots, step, ts }` with get/set/clear/subscribe, sessionStorage-backed (survives Cmd+R, cleared on app restart so last week's event is never offered). A pointer only — no queue, no scanning, adoption is always opt-in.
- Import sets the anchor to the imported destination after a successful run; the rename hand-off keeps it in step; a completed rename advances it to `step: 'rename'`.
- The rename module now seeds its roots from the anchor first, then the `import.destination` preference, then empty.

No visible UI yet — the landing-page "current folder" row and the review/culling offers arrive in later stages (next PR adds the rename → review chain).

## Tests
- New `frontend/tests/workingFolder.test.js` (12 tests): get/set/clear/subscribe, ts stamping, sessionStorage persistence.
- `npm test`: 488 passed at this stage (499 including the stacked follow-up). `npm run build:workspace`: OK.