### PR TITLE
Δ%-tooltip och omläsnings-snurra i räknestatistiken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 - **Gallra spelare och Räkna spelare förväljer eventmappen.** Öppnas endera modulen utan en delad scan-scope att ärva förväljs mappfältet från arbetsmapp-ankaret (satt av import/namnbyte) — enbart som förval, aldrig en automatisk skanning/körning (användaren trycker själv på kör-kontrollen). En befintlig scan-scope vinner alltid över ankaret.
 
 ### Changed
+- **Förklarande tooltip på Δ%-kolumnen.** Peka på Δ%-kolumnens huvud eller celler (i både Räkna spelare-tabellen och Gallra-vyns levande räknekolumn) för en förklaring: Δ% är avvikelsen från baslinjen — medianen eller medelvärdet av bildantalet för de inkluderade spelarna (positivt = fler bilder än baslinjen, negativt = färre).
+- **Omläsnings-snurra i gallringens räknekolumn.** Räknekolumnens huvud visar nu en liten snurra medan `POST /players/count` läses om (t.ex. efter ett baslinjebyte); slotten har fast storlek så den aldrig knuffar kontrollerna bredvid.
 - **Progressindikator vid NEF-namnbyte.** Både **Förhandsgranska** och **Byt namn** visar nu en förloppsindikator ("Läser EXIF… {klart}/{totalt}") medan EXIF läses, i stället för enbart disablade knappar. EXIF-läsningen delas upp i batchar så förloppet kan rapporteras löpande över WebSocket i stället för en enda lång paus; batcharna slås ihop och sorteras om deterministiskt så suffixen (-NN) för dubbletter av tidsstämplar blir oförändrade. **Byt namn** återanvänder dessutom förhandsgranskningens plan när filerna är oförändrade (samma request och oförändrad mtime/storlek per fil) och hoppar då över EXIF-omläsningen helt; vid minsta avvikelse görs en full omläsning.
 
 ### Fixed

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -261,7 +261,8 @@ antal.
 1. Öppna **Räkna spelare** (`Cmd+Shift+K`). Ange en mapp och/eller ett wildcard
    i balken högst upp, välj filtyp (vanligen `jpg / jpeg`) och ev. datum-span,
    och klicka **Räkna**. Tabellen visar antal bilder per spelare, andel, avvikelse
-   från medianen i procent (Δ%, grön/gul/röd) och antal (ΔN), en fördelningsstapel
+   från baslinjen i procent (Δ%, grön/gul/röd — peka på kolumnen för en
+   förklaring) och antal (ΔN), en fördelningsstapel
    relativt baslinjen (baslinjen = halva stapeln) samt en **tidslinje** som visar
    när spelarens bilder togs under passet. Bocka i **Per match** för samma
    uppställning per automatiskt detekterad match — varje match visar även en
@@ -320,7 +321,9 @@ antal.
    antal förändras. I räknekolumnens huvud finns en liten **Baslinje**-väljare
    (Median/Medel) som styr referensen för över-/underrepresentation; den delar
    inställning med Räkna spelare-fliken (ändrar du här ändras även den, och
-   valet kvarstår mellan omstarter). Även de **exkluderade grupperna**
+   valet kvarstår mellan omstarter). En liten snurra i kolumnhuvudet visas
+   medan räkningen läses om (t.ex. efter ett baslinjebyte). Även de
+   **exkluderade grupperna**
    (tränare/gruppbilder/publik/under tröskeln) är klickbara där för att
    filtrera/markera personen,
    och **högerklick på ett namn** (spelare eller exkluderad) ger samma

--- a/frontend/src/i18n/sv/culling.js
+++ b/frontend/src/i18n/sv/culling.js
@@ -77,6 +77,7 @@ module.exports = {
       "delta": "Δ%",
       "distribution": "Fördelning"
     },
+    "deltaTitle": "Avvikelse från baslinjen — medianen eller medelvärdet av bildantalet för de inkluderade spelarna. Positivt = fler bilder än baslinjen, negativt = färre.",
     "excludedLabels": {
       "tranare": "Tränare",
       "grupp": "Gruppbilder",

--- a/frontend/src/i18n/sv/playerCount.js
+++ b/frontend/src/i18n/sv/playerCount.js
@@ -66,6 +66,7 @@ module.exports = {
     "count": "Antal",
     "pct": "%",
     "deltaPct": "Δ%",
+    "deltaTitle": "Avvikelse från baslinjen — medianen eller medelvärdet av bildantalet för de inkluderade spelarna. Positivt = fler bilder än baslinjen, negativt = färre.",
     "deltaN": "ΔN",
     "distribution": "Fördelning",
     "timeline": "Tidslinje",

--- a/frontend/src/renderer/components/CullingModule.css
+++ b/frontend/src/renderer/components/CullingModule.css
@@ -116,6 +116,23 @@
   color: var(--text-tertiary, var(--text-secondary));
 }
 
+/* Fixed-size slot for the stats refetch spinner: reserving the space means
+   toggling the spinner on/off never reflows the header controls next to it. */
+.culling-stats-loading {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+}
+
+.culling-stats-loading .loading-spinner--sm {
+  width: 12px;
+  height: 12px;
+  border-width: 2px;
+}
+
 .culling-stats-empty {
   padding: 8px 10px;
   color: var(--text-secondary);

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -78,6 +78,9 @@ export function CullingModule({ node }) {
   // Live per-player counts for the current scope (from /players/count), shown in
   // the left stats column and refreshed as files are culled.
   const [stats, setStats] = useState(null);
+  // In-flight flag for the stats column, so the header can show a small spinner
+  // while a /players/count refetch is pending (e.g. after a baseline change).
+  const [statsLoading, setStatsLoading] = useState(false);
   // Shared counting settings (baseline / min_images), synced with Räkna spelare.
   // A ref mirrors the value so the many stats-loading callbacks can read it fresh
   // without listing it as a dependency (like playerSessionParams() below).
@@ -267,6 +270,7 @@ export function CullingModule({ node }) {
     async (scope) => {
       if (!scope) return;
       const seq = ++statsSeqRef.current;
+      setStatsLoading(true);
       try {
         // Carry the shared session-only right-click moves (read fresh per
         // request) so the live column agrees with Räkna spelare.
@@ -278,6 +282,10 @@ export function CullingModule({ node }) {
         setStats(data);
       } catch {
         if (seq === statsSeqRef.current) setStats(null);
+      } finally {
+        // Only the latest request clears the flag, so a superseded response
+        // can't hide the spinner while a newer refetch is still in flight.
+        if (seq === statsSeqRef.current) setStatsLoading(false);
       }
     },
     [api]
@@ -1198,6 +1206,7 @@ export function CullingModule({ node }) {
         <div className="culling-body" ref={bodyRef}>
           <CullingStats
             stats={stats}
+            loading={statsLoading}
             mode={viewMode}
             selected={viewMode === 'grid' ? highlightPlayer : player}
             width={statsWidth}

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -500,8 +500,12 @@ export function CullingModule({ node }) {
         setHasRun(false);
         // The discarded adopt load left isLoading true (its finally skips the
         // seq-mismatched response); reset it so the cleared workspace shows the
-        // "välj mapp" hint instead of a stuck "…".
+        // "välj mapp" hint instead of a stuck "…". Same for the stats spinner:
+        // an in-flight /players/count is seq-fenced by the bump above, so its
+        // finally never clears the flag — reset it here or the header spinner
+        // sticks forever in the emptied workspace.
         setIsLoading(false);
+        setStatsLoading(false);
         lastQueryRef.current = null;
         // Clear the shared scope too, so Räkna spelare (or a culling remount)
         // doesn't adopt the now-discarded selection.

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -858,7 +858,7 @@ function PlayerTable({ players, baseline, timeRange, onPlayerClick, onNameContex
           <th>{t('playerCount.table.name')}</th>
           <th className="num">{t('playerCount.table.count')}</th>
           <th className="num">{t('playerCount.table.pct')}</th>
-          <th className="num">{t('playerCount.table.deltaPct')}</th>
+          <th className="num" title={t('playerCount.table.deltaTitle')}>{t('playerCount.table.deltaPct')}</th>
           <th className="num">{t('playerCount.table.deltaN')}</th>
           <th className="bar-col">{t('playerCount.table.distribution')}</th>
           <th className="spark-col">{t('playerCount.table.timeline')}</th>
@@ -888,7 +888,7 @@ function PlayerTable({ players, baseline, timeRange, onPlayerClick, onNameContex
             <td>{p.name}</td>
             <td className="num">{p.count}</td>
             <td className="num">{p.pct}%</td>
-            <td className={`num delta delta-${p.level}`}>
+            <td className={`num delta delta-${p.level}`} title={t('playerCount.table.deltaTitle')}>
               {p.delta_pct > 0 ? '+' : ''}{p.delta_pct}%
             </td>
             <td className={`num delta delta-${p.level}`}>

--- a/frontend/src/renderer/components/culling/StatsPanel.jsx
+++ b/frontend/src/renderer/components/culling/StatsPanel.jsx
@@ -8,6 +8,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import { t } from '../../../i18n/index.js';
+import { LoadingSpinner } from '../shared/ProgressBar.jsx';
 
 const EXCLUDED_KEYS = ['tranare', 'grupp', 'publik', 'below_threshold'];
 
@@ -73,7 +74,7 @@ function CullingExcluded({ excluded, onSelect, onNameContextMenu }) {
  * capture-phase Enter/Esc handler yields to a focused role="button" so a keyed
  * Enter here filters instead of starting a rename.
  */
-export function CullingStats({ stats, selected, onSelect, onActivate, mode, width, baseline, onBaselineChange, onNameContextMenu }) {
+export function CullingStats({ stats, loading, selected, onSelect, onActivate, mode, width, baseline, onBaselineChange, onNameContextMenu }) {
   const players = stats?.players || [];
   const maxCount = players.reduce((m, p) => Math.max(m, p.count), 1);
   const clickTimerRef = useRef(null);
@@ -110,6 +111,11 @@ export function CullingStats({ stats, selected, onSelect, onActivate, mode, widt
     <div className="culling-stats" style={{ flex: `0 0 ${width}px` }}>
       <div className="culling-stats-header">
         <span>{t('culling.stats.header')}</span>
+        {/* Fixed-width slot so the spinner appearing/disappearing never shifts
+            the controls next to it. */}
+        <span className="culling-stats-loading" aria-hidden={!loading}>
+          {loading && <LoadingSpinner size="sm" />}
+        </span>
         {onBaselineChange && (
           <select
             className="form-select culling-stats-baseline-select"
@@ -139,7 +145,7 @@ export function CullingStats({ stats, selected, onSelect, onActivate, mode, widt
                 <th>{t('culling.stats.columns.name')}</th>
                 <th className="num">{t('culling.stats.columns.count')}</th>
                 <th className="num">{t('culling.stats.columns.pct')}</th>
-                <th className="num">{t('culling.stats.columns.delta')}</th>
+                <th className="num" title={t('culling.stats.deltaTitle')}>{t('culling.stats.columns.delta')}</th>
                 <th className="bar-col">{t('culling.stats.columns.distribution')}</th>
               </tr>
             </thead>
@@ -175,7 +181,7 @@ export function CullingStats({ stats, selected, onSelect, onActivate, mode, widt
                   <td className="culling-stat-name">{p.name}</td>
                   <td className="num">{p.count}</td>
                   <td className="num">{p.pct}%</td>
-                  <td className={`num delta delta-${p.level || 'ok'}`}>
+                  <td className={`num delta delta-${p.level || 'ok'}`} title={t('culling.stats.deltaTitle')}>
                     {p.delta_pct > 0 ? '+' : ''}{p.delta_pct}%
                   </td>
                   <td className="bar-col">

--- a/frontend/tests/cullingModuleFence.test.jsx
+++ b/frontend/tests/cullingModuleFence.test.jsx
@@ -396,6 +396,33 @@ describe('CullingModule — gridThumbnailCache.clear() wiring (#114)', () => {
   });
 });
 
+describe('CullingModule — stats spinner vs bare --clear', () => {
+  it('resets the stats spinner when a bare --clear discards an in-flight /players/count', async () => {
+    const { container } = await mountCulling();
+    await loadFiles();
+    // Start a stats refetch that never resolves — the header spinner turns on.
+    h.api.post.mockImplementation((path) => {
+      if (path.includes('/players/count')) return new Promise(() => {});
+      if (path.includes('/culling/files')) return Promise.resolve(h.nextFiles);
+      return Promise.resolve({});
+    });
+    const handler = h.registry.get('culling-load');
+    await act(async () => {
+      await handler({ roots: ['/p'], clear: true, recursive: false });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.culling-stats-loading .loading-spinner')).toBeTruthy();
+    // Bare --clear while that request is in flight: the seq bump discards the
+    // response, so its finally can never clear the flag — the clear path must
+    // reset it itself or the spinner sticks forever in the emptied workspace.
+    await act(async () => {
+      await handler({ roots: [], clear: true });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.culling-stats-loading .loading-spinner')).toBeNull();
+  });
+});
+
 describe('CullingModule — stats panel interaction (characterization)', () => {
   it('renders a row per counted player from the stats response', async () => {
     const { container } = await mountCulling();

--- a/frontend/tests/cullingStatsPanel.test.jsx
+++ b/frontend/tests/cullingStatsPanel.test.jsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { CullingStats } from '../src/renderer/components/culling/StatsPanel.jsx';
+import { t } from '../src/i18n/index.js';
+
+// The stats panel is mostly presentational, but two behaviours are worth
+// pinning: the Δ% column carries the explanatory tooltip (header + cells), and
+// the header shows a spinner only while a refetch is in flight.
+
+const STATS = {
+  baseline: 5,
+  players: [
+    { name: 'Alice', count: 8, pct: 40, delta_pct: 60, level: 'high' },
+    { name: 'Bob', count: 3, pct: 15, delta_pct: -40, level: 'high' },
+  ],
+  excluded: null,
+};
+
+describe('CullingStats', () => {
+  it('puts the deltaTitle tooltip on the Δ% header and cells', () => {
+    const { container } = render(<CullingStats stats={STATS} width={200} mode="loupe" />);
+    const tooltip = t('culling.stats.deltaTitle');
+    const titled = [...container.querySelectorAll(`[title="${tooltip}"]`)];
+    // One header cell + one per player row.
+    expect(titled.length).toBe(1 + STATS.players.length);
+  });
+
+  it('shows the spinner only while loading', () => {
+    const { container: idle } = render(
+      <CullingStats stats={STATS} width={200} mode="loupe" loading={false} />
+    );
+    expect(idle.querySelector('.loading-spinner')).toBeNull();
+
+    const { container: busy } = render(
+      <CullingStats stats={STATS} width={200} mode="loupe" loading={true} />
+    );
+    expect(busy.querySelector('.loading-spinner')).not.toBeNull();
+  });
+
+  it('keeps the fixed-size spinner slot present even when idle (no layout shift)', () => {
+    const { container } = render(
+      <CullingStats stats={STATS} width={200} mode="loupe" loading={false} />
+    );
+    // Slot always rendered; only its spinner child toggles.
+    expect(container.querySelector('.culling-stats-loading')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
PR5 i serien "Räkna spelare ↔ Gallra" (planen `eager-floating-walrus.md`, rad 5). Bygger på #213 (delad baslinje).

Två små polish-punkter i räknestatistiken:

## 1. Förklarande Δ%-tooltip
Δ%-kolumnen är kryptisk. Lade till en svensk `title`-tooltip (via i18n-nyckel) på Δ%-kolumnens **huvud och celler** i båda tabellerna:
- Gallringens levande statistikpanel (`culling/StatsPanel.jsx`)
- Räkna spelare-tabellen (`PlayerCountModule.jsx`, `PlayerTable`)

Texten förklarar att Δ% är avvikelsen från baslinjen — medianen eller medelvärdet av bildantalet för de inkluderade spelarna (positivt = fler bilder än baslinjen, negativt = färre). Formuleringen verifierad mot backend (`core/playerstats.summarize_counter`: `delta_pct = 100 * (count - baseline) / baseline`). En delad nyckel per modulfil (`culling.stats.deltaTitle`, `playerCount.table.deltaTitle`).

## 2. Omläsnings-snurra
Sedan #213 läses gallringens statistik om när räkne-inställningarna ändras. Lade till en liten `statsLoading`-driven snurra i `culling-stats-header` medan `loadStats` (`POST /players/count`) är i flykten. Återanvänder delade `LoadingSpinner`. Slotten har fast storlek (14px) så den aldrig knuffar kontrollerna bredvid; temavariabler, ljust + mörkt.

## Tester & docs
- `npm test`: 540 tester gröna (nytt `tests/cullingStatsPanel.test.jsx` täcker tooltip-närvaro + spinner-toggle).
- `npm run build:workspace`: grönt.
- `docs/user/workspace-guide.md`: Δ%-beskrivningen + snurra noterade.
- `CHANGELOG.md` `[Unreleased]`.