### PR TITLE
Clear culling stats panel when scan scope changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+### Fixed
+- **Innehållsmix i Gallra-vyns räknekolumn.** Fillistan (`/culling/files`) och spelarräkningen (`POST /players/count`) är två oberoende anrop — listan resolvar snabbt, räkne-skanningen långsamt — så vid ett scope-byte (nytt urval/mapp/datumspann) visade räknekolumnen förra urvalets spelare bredvid den nya fillistan tills skanningen hann klart. Panelen nollställs nu direkt när skanningsscopet ändras (roots/globs/rekursiv/datum/filtypsförval), medan ändringar som inte rör skanningsscopet — spelarfilter-klick, cull/rename-omläsning och baslinje-/min-bilder-byte — behåller siffrorna med enbart huvudets snurra.
+
 ## [1.6.0] - 2026-07-15
 
 ### Added

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -148,6 +148,13 @@ export function CullingModule({ node }) {
   // list drives which files `x`/Delete trashes.
   const reqSeqRef = useRef(0);
   const statsSeqRef = useRef(0);
+  // Last scan scope the stats panel was loaded for (a stable key of ONLY the
+  // scanning fields — roots/globs/recursive/dates/preset). When the scan scope
+  // changes we clear the panel immediately, so the previous selection's players
+  // can't linger next to the new file list until the slow /players/count lands.
+  // Deliberately excludes baseline/min_images/player: those refetch in place and
+  // must keep the numbers visible (spinner only), not blank the panel.
+  const lastStatsScopeKeyRef = useRef(null);
   // New path of a just-renamed file to advance past, honored by whichever
   // loadList resolves last so a racing folder-watch refresh can't clobber the
   // auto-advance. Consumed (cleared) by that reload.
@@ -272,6 +279,23 @@ export function CullingModule({ node }) {
   const loadStats = useCallback(
     async (scope) => {
       if (!scope) return;
+      // Blank the panel the instant the SCAN scope changes, so the previous
+      // selection's player rows don't sit next to the freshly-loaded file list
+      // until the slow /players/count for the new scope returns. Keyed on the
+      // scanning fields only — a player-filter click, a cull/rename refresh, or a
+      // baseline/min-images change keeps the numbers up (with the header spinner).
+      const scopeKey = JSON.stringify({
+        roots: scope.roots || [],
+        globs: scope.globs || [],
+        recursive: scope.recursive ?? null,
+        date_from: scope.date_from ?? null,
+        date_to: scope.date_to ?? null,
+        extension_preset: scope.extension_preset ?? null,
+      });
+      if (scopeKey !== lastStatsScopeKeyRef.current) {
+        setStats(null);
+        lastStatsScopeKeyRef.current = scopeKey;
+      }
       const seq = ++statsSeqRef.current;
       setStatsLoading(true);
       try {
@@ -500,6 +524,9 @@ export function CullingModule({ node }) {
         gridThumbnailCache.clear();
         setCurrentIndex(-1);
         setStats(null);
+        // Forget the scan-scope key so a later reload of the SAME scope still
+        // re-blanks the panel (loadStats compares against this ref).
+        lastStatsScopeKeyRef.current = null;
         setHasRun(false);
         // The discarded adopt load left isLoading true (its finally skips the
         // seq-mismatched response); reset it so the cleared workspace shows the

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -26,7 +26,7 @@ import { getScanScope, setScanScope, scanScopeHasSelection, takeExternalLoad } f
 import { getWorkingFolder } from '../shared/workingFolder.js';
 import { isTabsetActive } from '../hooks/useActiveTabset.js';
 import { extOf } from '../shared/fileExts.js';
-import { statsScopeFromQuery, isRaw, globBaseDir, basename, stripExt } from './culling/cullingQueryUtils.js';
+import { statsScopeFromQuery, scanScopeKey, isRaw, globBaseDir, basename, stripExt } from './culling/cullingQueryUtils.js';
 import { CullingStats } from './culling/StatsPanel.jsx';
 import { useCullingPreview } from './culling/useCullingPreview.js';
 import { useDecodedImage } from '../hooks/useDecodedImage.js';
@@ -284,14 +284,7 @@ export function CullingModule({ node }) {
       // until the slow /players/count for the new scope returns. Keyed on the
       // scanning fields only — a player-filter click, a cull/rename refresh, or a
       // baseline/min-images change keeps the numbers up (with the header spinner).
-      const scopeKey = JSON.stringify({
-        roots: scope.roots || [],
-        globs: scope.globs || [],
-        recursive: scope.recursive ?? null,
-        date_from: scope.date_from ?? null,
-        date_to: scope.date_to ?? null,
-        extension_preset: scope.extension_preset ?? null,
-      });
+      const scopeKey = scanScopeKey(scope);
       if (scopeKey !== lastStatsScopeKeyRef.current) {
         setStats(null);
         lastStatsScopeKeyRef.current = scopeKey;

--- a/frontend/src/renderer/components/culling/cullingQueryUtils.js
+++ b/frontend/src/renderer/components/culling/cullingQueryUtils.js
@@ -16,21 +16,35 @@ import { RAW_EXTS } from '../../shared/fileExts.js';
 // pure scan-scope) it leaves those out and the backend defaults apply. Exclusions
 // still come from the count endpoint's config so coaches/audience/below-threshold
 // names land in `excluded`, not in the live count.
+// The scanning dimensions that define WHICH files a count scans. Single source of
+// truth shared by statsScopeFromQuery (which builds the scope from these fields)
+// and scanScopeKey (which keys the live-stats blank-on-scope-change guard). Adding
+// a new scanning dimension here updates both, so the panel can't silently stop
+// blanking on a new field. Deliberately excludes baseline/min_images (counting
+// options, appended separately) and player (a file-list filter, not a scan field).
+export const SCAN_SCOPE_FIELDS = ['roots', 'globs', 'extension_preset', 'recursive', 'date_from', 'date_to'];
+
 export function statsScopeFromQuery(q, countSettings) {
   if (!q) return null;
-  const scope = {
-    roots: q.roots,
-    globs: q.globs,
-    extension_preset: q.extension_preset,
-    recursive: q.recursive,
-    date_from: q.date_from,
-    date_to: q.date_to,
-  };
+  const scope = {};
+  for (const f of SCAN_SCOPE_FIELDS) scope[f] = q[f];
   if (countSettings) {
     scope.baseline = countSettings.baseline;
     scope.min_images = countSettings.minImages;
   }
   return scope;
+}
+
+// Stable key over ONLY the scan fields of a scope, for detecting a scan-scope
+// change (the live stats panel blanks when it changes). Fields are read in the
+// fixed SCAN_SCOPE_FIELDS order so the key is order-stable; a missing field
+// normalizes to null so absent vs. explicit-null don't key differently. Arrays
+// (roots/globs) compare by value via JSON.stringify.
+export function scanScopeKey(scope) {
+  if (!scope) return null;
+  const norm = {};
+  for (const f of SCAN_SCOPE_FIELDS) norm[f] = scope[f] ?? null;
+  return JSON.stringify(norm);
 }
 
 export function isRaw(p) {

--- a/frontend/tests/cullingQueryUtils.test.js
+++ b/frontend/tests/cullingQueryUtils.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   statsScopeFromQuery,
+  scanScopeKey,
   isRaw,
   globBaseDir,
   basename,
@@ -53,6 +54,39 @@ describe('statsScopeFromQuery', () => {
       baseline: 'mean',
       min_images: 5,
     });
+  });
+});
+
+describe('scanScopeKey', () => {
+  it('returns null for a falsy scope', () => {
+    expect(scanScopeKey(null)).toBeNull();
+    expect(scanScopeKey(undefined)).toBeNull();
+  });
+
+  it('keys equal for scopes differing only in baseline/min_images (counting options)', () => {
+    const base = statsScopeFromQuery({ roots: ['/a'], globs: [], extension_preset: 'jpg', recursive: true, date_from: null, date_to: null });
+    const withCounts = statsScopeFromQuery(
+      { roots: ['/a'], globs: [], extension_preset: 'jpg', recursive: true, date_from: null, date_to: null },
+      { baseline: 'mean', minImages: 9 }
+    );
+    expect(scanScopeKey(withCounts)).toBe(scanScopeKey(base));
+  });
+
+  it('keys differ when a scan field changes (roots / preset / recursive / dates / globs)', () => {
+    const s = { roots: ['/a'], globs: [], extension_preset: 'jpg', recursive: true, date_from: null, date_to: null };
+    const k = scanScopeKey(s);
+    expect(scanScopeKey({ ...s, roots: ['/b'] })).not.toBe(k);
+    expect(scanScopeKey({ ...s, globs: ['*.jpg'] })).not.toBe(k);
+    expect(scanScopeKey({ ...s, extension_preset: 'nef' })).not.toBe(k);
+    expect(scanScopeKey({ ...s, recursive: false })).not.toBe(k);
+    expect(scanScopeKey({ ...s, date_from: '2026-01-01' })).not.toBe(k);
+    expect(scanScopeKey({ ...s, date_to: '2026-02-01' })).not.toBe(k);
+  });
+
+  it('normalizes a missing field to null so absent vs. explicit-null key the same', () => {
+    const withNull = { roots: ['/a'], globs: [], extension_preset: 'jpg', recursive: true, date_from: null, date_to: null };
+    const missing = { roots: ['/a'], globs: [], extension_preset: 'jpg', recursive: true };
+    expect(scanScopeKey(missing)).toBe(scanScopeKey(withNull));
   });
 });
 

--- a/frontend/tests/cullingStatsScope.test.jsx
+++ b/frontend/tests/cullingStatsScope.test.jsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/react';
+
+// Scope-clearing tests for CullingModule's live stats panel.
+//
+// The file list (/culling/files) and the per-player counts (/players/count) are
+// two independent requests: the list resolves fast, the count scan is slow. When
+// the SCAN scope changes (a new selection, folder, date span…) the panel must
+// blank immediately so the previous selection's players can't sit next to the
+// freshly-repainted file list until the slow count lands. A change that does NOT
+// alter the scan scope — a player-filter click, a baseline/min-images tweak, a
+// cull/rename refresh — must instead keep the numbers up (header spinner only).
+//
+// The harness mirrors cullingModuleFence.test.jsx: everything the component
+// reaches outside its render is mocked, i18n strings stay REAL so assertions key
+// off the actual Swedish text (.culling-stats-empty renders "Inga …").
+
+const h = vi.hoisted(() => {
+  const registry = new Map(); // eventName -> latest useModuleEvent handler
+  const api = { get: vi.fn(), post: vi.fn() };
+  return { registry, api, nextFiles: { files: [], players: [] }, nextStats: {} };
+});
+
+vi.mock('../src/renderer/context/BackendContext.jsx', () => ({
+  useBackend: () => ({ api: h.api }),
+}));
+
+vi.mock('../src/renderer/hooks/useModuleEvent.js', () => ({
+  useModuleEvent: (eventName, handler) => {
+    if (eventName) h.registry.set(eventName, handler);
+  },
+  useModuleAPI: () => ({
+    emit: vi.fn(),
+    on: () => () => {},
+    waitForListeners: vi.fn().mockResolvedValue(true),
+    hasListeners: () => false,
+  }),
+}));
+
+import { CullingModule } from '../src/renderer/components/CullingModule.jsx';
+
+beforeAll(() => {
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (!window.localStorage) {
+    const store = new Map();
+    window.localStorage = {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      clear: () => store.clear(),
+    };
+  }
+});
+
+const FILES_A = [
+  { path: '/a/260601_120000_Alice.jpg', basename: '260601_120000_Alice.jpg', mtime_ms: 100, size: 10 },
+  { path: '/a/260601_120100_Bob.jpg', basename: '260601_120100_Bob.jpg', mtime_ms: 200, size: 20 },
+];
+const FILES_B = [
+  { path: '/b/260701_090000_Carol.jpg', basename: '260701_090000_Carol.jpg', mtime_ms: 300, size: 30 },
+];
+
+const STATS_A = {
+  baseline: 5,
+  players: [
+    { name: 'Alice', count: 6, pct: 60, delta_pct: 10, level: 'ok' },
+    { name: 'Bob', count: 4, pct: 40, delta_pct: -5, level: 'low' },
+  ],
+  excluded: null,
+};
+const STATS_B = {
+  baseline: 3,
+  players: [{ name: 'Carol', count: 3, pct: 100, delta_pct: 0, level: 'ok' }],
+  excluded: null,
+};
+
+// A controllable /players/count: when armed, the next count request never
+// resolves on its own — the test resolves it explicitly via `resolveStats`.
+let hangStats = false;
+let pendingStatsResolve = null;
+function resolveStats(value) {
+  const r = pendingStatsResolve;
+  pendingStatsResolve = null;
+  r?.(value);
+}
+
+let originalFetch;
+
+beforeEach(() => {
+  cleanup();
+  h.registry.clear();
+  h.api.get.mockReset();
+  h.api.post.mockReset();
+  h.nextFiles = { files: FILES_A, players: ['Alice', 'Bob'] };
+  h.nextStats = STATS_A;
+  hangStats = false;
+  pendingStatsResolve = null;
+  h.api.post.mockImplementation((path) => {
+    if (path.includes('/culling/files')) return Promise.resolve(h.nextFiles);
+    if (path.includes('/players/count')) {
+      if (hangStats) return new Promise((resolve) => { pendingStatsResolve = resolve; });
+      return Promise.resolve(h.nextStats);
+    }
+    if (path.includes('/culling/rename')) return Promise.resolve({ path: '/renamed.jpg' });
+    return Promise.resolve({});
+  });
+  try { localStorage.clear(); } catch { /* ignore */ }
+  originalFetch = global.fetch;
+  global.fetch = vi.fn(() => new Promise(() => {}));
+  globalThis.window.ansiktenAPI = {
+    watchFolder: vi.fn(),
+    unwatchFolder: vi.fn(),
+    onFolderChanged: () => () => {},
+    invoke: vi.fn().mockResolvedValue([]),
+  };
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+async function mountCulling(node = null) {
+  let utils;
+  await act(async () => {
+    utils = render(<CullingModule node={node} />);
+    await Promise.resolve();
+  });
+  return utils;
+}
+
+// Load a scope through the CLI hand-off event so files + stats resolve for it.
+async function loadFilesA() {
+  h.nextFiles = { files: FILES_A, players: ['Alice', 'Bob'] };
+  h.nextStats = STATS_A;
+  const handler = h.registry.get('culling-load');
+  await act(async () => {
+    await handler({ roots: ['/a'], clear: true, recursive: false });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function statRows(container) {
+  return container.querySelectorAll('.culling-stat-row');
+}
+function countPost(fragment) {
+  return h.api.post.mock.calls.filter(([p]) => p.includes(fragment)).length;
+}
+
+describe('CullingModule — stats panel clears on scan-scope change', () => {
+  it('blanks the panel the moment a new scan scope loads, then fills it when the count lands', async () => {
+    const { container } = await mountCulling();
+    await loadFilesA();
+    // Scope A is fully loaded: Alice/Bob rows are shown next to A's file list.
+    expect(statRows(container)).toHaveLength(2);
+    expect(container.querySelector('.culling-stats-empty')).toBeNull();
+
+    // Switch to scope B (a Räkna-spelare hand-off to a different folder) while the
+    // /players/count for B is held pending: the list repaints to B fast, but B's
+    // counts have not arrived yet.
+    hangStats = true;
+    h.nextFiles = { files: FILES_B, players: ['Carol'] };
+    const cullPlayer = h.registry.get('cull-player');
+    await act(async () => {
+      await cullPlayer({ roots: ['/b'], name: 'Carol' });
+      await Promise.resolve();
+    });
+
+    // The file list has repainted to B, and the stale scope-A players are GONE —
+    // the panel is empty rather than showing Alice/Bob beside B's files.
+    expect(container.querySelectorAll('.culling-files li')).toHaveLength(1);
+    expect(statRows(container)).toHaveLength(0);
+    expect(container.querySelector('.culling-stats-empty')).toBeTruthy();
+
+    // B's count arrives → B's rows fill in.
+    await act(async () => {
+      resolveStats(STATS_B);
+      await Promise.resolve();
+    });
+    const rows = statRows(container);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].querySelector('.culling-stat-name').textContent).toBe('Carol');
+  });
+
+  it('does NOT blank the panel on a player-only filter (same scan scope)', async () => {
+    const { container } = await mountCulling();
+    await loadFilesA();
+    expect(statRows(container)).toHaveLength(2);
+
+    // Click a stats row (loupe): filters the list to that player. The scan scope
+    // is unchanged (same roots), so the refetch must keep the numbers visible.
+    hangStats = true;
+    const aliceRow = [...statRows(container)].find((r) => r.textContent.includes('Alice'));
+    await act(async () => {
+      fireEvent.click(aliceRow);
+      await Promise.resolve();
+    });
+
+    // A refetch was issued, but the panel still shows the players (spinner only) —
+    // no blank.
+    expect(statRows(container)).toHaveLength(2);
+    expect(container.querySelector('.culling-stats-empty')).toBeNull();
+    // Resolve the pending refetch so no state update escapes act().
+    await act(async () => { resolveStats(STATS_A); await Promise.resolve(); });
+  });
+
+  it('does NOT blank the panel on a baseline change (same scan scope)', async () => {
+    const { container } = await mountCulling();
+    await loadFilesA();
+    expect(statRows(container)).toHaveLength(2);
+
+    // Change the baseline select to a value different from its current one: this
+    // refetches the count (baseline is folded into the scope) but the scanning
+    // fields are unchanged, so the panel must not blank.
+    hangStats = true;
+    const before = countPost('/players/count');
+    const select = container.querySelector('select.culling-stats-baseline-select');
+    const other = select.value === 'mean' ? 'median' : 'mean';
+    await act(async () => {
+      fireEvent.change(select, { target: { value: other } });
+      await Promise.resolve();
+    });
+
+    expect(countPost('/players/count')).toBe(before + 1); // a refetch did fire
+    expect(statRows(container)).toHaveLength(2);          // …but nothing blanked
+    expect(container.querySelector('.culling-stats-empty')).toBeNull();
+    await act(async () => { resolveStats(STATS_A); await Promise.resolve(); });
+  });
+});


### PR DESCRIPTION
## Problem

The culling view's player-count column (\`CullingStats\`) is fed by \`POST /players/count\` while the file list is fed by \`/culling/files\` — two independent requests with separate in-flight counters. The list query is filtered and fast; the count scan is slow. On a scope change (e.g. the \`cull-player\` hand-off from Räkna spelare, adopt-on-mount, or a preset change) the previous selection's players lingered next to the freshly repainted file list until the slow scan landed. Nothing ever cleared \`stats\` on a scope change — the only \`setStats(null)\` was the CLI bare \`--clear\` path.

## Fix

\`loadStats\` now computes a stable key of the scanning fields only (\`roots\`, \`globs\`, \`recursive\`, \`date_from\`, \`date_to\`, \`extension_preset\`) and blanks the panel the instant that key changes. The key deliberately excludes \`baseline\`/\`min_images\`/\`player\`, so a player-filter click, a cull/rename refresh, or a baseline/min-images change keeps the numbers visible (header spinner only) instead of flashing the panel empty. The bare \`--clear\` path resets the key ref so a later reload of the same scope re-blanks correctly.

## Tests

New \`frontend/tests/cullingStatsScope.test.jsx\` (236 lines): scope hand-off blanks stale rows while the new count is pending; player-only filter change does not blank; baseline/min-images change does not blank.

Full suite: 65 files / 609 tests passed; \`npm run build:workspace\` clean.