### PR TITLE
Clearable scan scope: publish empty selection, culling clear button, chip rescan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+### Added
+- **"Rensa"-knapp i Gallra-vyns filterrad.** En ny sekundärknapp **Rensa** (efter "+ Mapp") tömmer gallringsarbetsytan tillbaka till "välj mapp"-läget — fillista, räknekolumn, cachade miniatyrer och mappbevakning nollställs och det delade skanningsscopet rensas — med exakt samma semantik som CLI:t `ansikten culling --clear`. Knappen är avaktiverad när det inte finns något att rensa. CLI:ts `--clear`-väg och knappen delar nu en gemensam `clearWorkspace()`-rutin.
+
+### Changed
+- **Chip-borttagning räknar om/rensar skanningsscopet.** Att ta bort en mapp-chip i **Räkna spelare** publicerar nu det uppdaterade (eventuellt tomma) skanningsscopet och räknar om — tas den sista chippen bort nollställs resultatet och det delade scopet i stället för att skicka en tom fråga (som annars hade räknat hela standardurvalet), så Gallra spelare speglar den tömda selektionen vid nästa öppning. Tidigare uppdaterade chip-borttagning bara det lokala fältet utan att fyra av någon omräkning, så ett tomt urval kunde aldrig publiceras. **Gallra-vyns** egna mapp-chips led av samma felklass — de bytte bara `roots` utan att skanna om — och re-skannar nu med kvarvarande mappar (togs den sista bort tömmer de arbetsytan).
+
 ### Fixed
 - **Innehållsmix i Gallra-vyns räknekolumn.** Fillistan (`/culling/files`) och spelarräkningen (`POST /players/count`) är två oberoende anrop — listan resolvar snabbt, räkne-skanningen långsamt — så vid ett scope-byte (nytt urval/mapp/datumspann) visade räknekolumnen förra urvalets spelare bredvid den nya fillistan tills skanningen hann klart. Panelen nollställs nu direkt när skanningsscopet ändras (roots/globs/rekursiv/datum/filtypsförval), medan ändringar som inte rör skanningsscopet — spelarfilter-klick, cull/rename-omläsning och baslinje-/min-bilder-byte — behåller siffrorna med enbart huvudets snurra.
 

--- a/docs/user/workspace-guide.md
+++ b/docs/user/workspace-guide.md
@@ -98,6 +98,12 @@ zoomat in. Även bildvisarens zoomtangenter fungerar här: `+`/`-` zoomar in/ut,
 börjar autoanpassad (fit-to-window), så att stega mellan filer nollställer
 zoomen automatiskt. NEF/RAW visas via samma konvertering som tidigare.
 
+I filterraden finns knappen **Rensa** (bredvid **+ Mapp**) som tömmer
+arbetsytan tillbaka till "välj mapp"-läget — fillista, räknekolumn och
+mappval nollställs — med samma verkan som CLI:t `ansikten culling --clear`.
+Ta bort en enskild mapp med krysset på dess chip: kvarvarande mappar skannas
+om automatiskt, och tas den sista mappen bort töms arbetsytan.
+
 | Genväg | Funktion |
 |--------|----------|
 | `↑` / `↓` (`k` / `j`) | **Enkelbild:** föregående/nästa. **Rutnät:** upp/ned en rad |

--- a/frontend/src/i18n/sv/culling.js
+++ b/frontend/src/i18n/sv/culling.js
@@ -2,6 +2,7 @@
 module.exports = {
   "filterBar": {
     "addFolder": "+ Mapp",
+    "clear": "Rensa",
     "fileType": "Filtyp",
     "player": "Spelare",
     "allPlayers": "Alla spelare",

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -222,6 +222,42 @@ export function CullingModule({ node }) {
     watchedDirsRef.current = desired;
   }, []);
 
+  // Empty the culling workspace back to the "pick a folder" state: drop the scan
+  // scope (roots/globs/dates/player/glob), the file list + stats, all cached
+  // thumbnails and folder watches, and the shared scan scope so neither Räkna
+  // spelare nor a culling remount re-adopts the discarded selection. Shared by
+  // the CLI `--clear` hand-off and the Rensa button. Bumps the request seqs so an
+  // in-flight mount-adopt load/stats is discarded when it returns instead of
+  // repopulating the just-cleared workspace; resets the loading flags because
+  // those seq-fenced responses skip their own `finally` cleanup.
+  const clearWorkspace = useCallback(() => {
+    ++reqSeqRef.current;
+    ++statsSeqRef.current;
+    setRoots([]);
+    setCarriedGlobs([]);
+    setPlayer('');
+    setGlob('');
+    setDateFrom(null);
+    setDateTo(null);
+    setRecursive(true);
+    setFiles([]);
+    // Free the grid's cached thumbnail blobs so a later scope doesn't inherit
+    // stale entries (guarded against any in-flight fetch by the cache's
+    // generation counter).
+    gridThumbnailCache.clear();
+    setCurrentIndex(-1);
+    setStats(null);
+    // Forget the scan-scope key so a later reload of the SAME scope still
+    // re-blanks the panel (loadStats compares against this ref).
+    lastStatsScopeKeyRef.current = null;
+    setHasRun(false);
+    setIsLoading(false);
+    setStatsLoading(false);
+    lastQueryRef.current = null;
+    setScanScope(null);
+    updateWatches(new Set());
+  }, [updateWatches]);
+
   // ----- listing ------------------------------------------------------
   const loadList = useCallback(
     async (query, { keepIndex = false, advancePastPath = null } = {}) => {
@@ -371,6 +407,32 @@ export function CullingModule({ node }) {
     updateWatches(watchDirs());
   }, [buildQuery, loadList, loadStats, updateWatches, watchDirs]);
 
+  // Remove one folder chip. Removing the last chip empties the workspace;
+  // otherwise re-scan with the remaining roots (same failure class as the stats
+  // module's chips, which used to only setRoots without re-querying). The re-scan
+  // is skipped until a query has actually run — while the user is still
+  // assembling the folder set (e.g. a working-folder prefill) there's nothing to
+  // recompute yet.
+  const removeRoot = useCallback((r) => {
+    const remaining = roots.filter((x) => x !== r);
+    if (remaining.length === 0) {
+      clearWorkspace();
+      return;
+    }
+    setRoots(remaining);
+    if (!lastQueryRef.current) return;
+    const query = buildQuery({ roots: remaining });
+    lastQueryRef.current = query;
+    loadList(query);
+    loadStats(statsScopeFromQuery(query, countSettingsRef.current));
+    const dirs = new Set(remaining);
+    for (const g of carriedGlobs) {
+      const base = globBaseDir(g);
+      if (base) dirs.add(base);
+    }
+    updateWatches(dirs);
+  }, [roots, carriedGlobs, buildQuery, loadList, loadStats, updateWatches, clearWorkspace]);
+
   // Auto-refresh on folder change.
   useEffect(() => {
     const unsubscribe = window.ansiktenAPI.onFolderChanged?.(() => {
@@ -489,6 +551,13 @@ export function CullingModule({ node }) {
       const nextRoots = data.clear
         ? incoming
         : Array.from(new Set([...roots, ...incoming]));
+
+      if (nextRoots.length === 0) {
+        // Bare --clear: empty the workspace back to the "pick a folder" state.
+        clearWorkspace();
+        return;
+      }
+
       // CLI controls recursion explicitly (default off — just the named
       // folder); reflect it in the toggle so the user sees the active scope.
       const nextRecursive = data.recursive ?? false;
@@ -502,40 +571,6 @@ export function CullingModule({ node }) {
       setGlob('');
       setDateFrom(null);
       setDateTo(null);
-
-      if (nextRoots.length === 0) {
-        // Bare --clear: empty the list and stop watching. Bump the request seqs
-        // so an in-flight load/stats from the mount-adopt (which fires when this
-        // tab freshly mounts and a prior shared scope exists) is discarded when
-        // it returns — otherwise it would repopulate the just-cleared workspace.
-        ++reqSeqRef.current;
-        ++statsSeqRef.current;
-        setFiles([]);
-        // Working set is being emptied — free the grid's cached thumbnail blobs
-        // so a later scope doesn't inherit stale entries (guarded against any
-        // in-flight fetch by the cache's generation counter).
-        gridThumbnailCache.clear();
-        setCurrentIndex(-1);
-        setStats(null);
-        // Forget the scan-scope key so a later reload of the SAME scope still
-        // re-blanks the panel (loadStats compares against this ref).
-        lastStatsScopeKeyRef.current = null;
-        setHasRun(false);
-        // The discarded adopt load left isLoading true (its finally skips the
-        // seq-mismatched response); reset it so the cleared workspace shows the
-        // "välj mapp" hint instead of a stuck "…". Same for the stats spinner:
-        // an in-flight /players/count is seq-fenced by the bump above, so its
-        // finally never clears the flag — reset it here or the header spinner
-        // sticks forever in the emptied workspace.
-        setIsLoading(false);
-        setStatsLoading(false);
-        lastQueryRef.current = null;
-        // Clear the shared scope too, so Räkna spelare (or a culling remount)
-        // doesn't adopt the now-discarded selection.
-        setScanScope(null);
-        updateWatches(new Set());
-        return;
-      }
 
       const query = {
         roots: nextRoots,
@@ -552,7 +587,7 @@ export function CullingModule({ node }) {
       loadStats(statsScopeFromQuery(query, countSettingsRef.current));
       updateWatches(new Set(nextRoots));
     },
-    [roots, preset, loadList, loadStats, updateWatches]
+    [roots, preset, loadList, loadStats, updateWatches, clearWorkspace]
   );
 
   // On open, adopt the shared scan scope (e.g. coming from Räkna spelare) when
@@ -1255,6 +1290,8 @@ export function CullingModule({ node }) {
     <div className="module-container culling">
       <CullingFilterBar
         addFolders={addFolders}
+        clearWorkspace={clearWorkspace}
+        canClear={roots.length > 0 || hasRun || files.length > 0}
         preset={preset}
         setPreset={setPreset}
         runFilter={runFilter}
@@ -1285,7 +1322,7 @@ export function CullingModule({ node }) {
                 variant="ghost"
                 size="sm"
                 className="culling-chip-x"
-                onClick={() => setRoots((rs) => rs.filter((x) => x !== r))}
+                onClick={() => removeRoot(r)}
               />
             </span>
           ))}

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -438,15 +438,18 @@ export function CullingModule({ node }) {
     updateWatches(watchDirs());
   }, [buildQuery, loadList, loadStats, updateWatches, watchDirs]);
 
-  // Remove one folder chip. Removing the last chip empties the workspace;
-  // otherwise re-scan with the remaining roots (same failure class as the stats
-  // module's chips, which used to only setRoots without re-querying). The re-scan
-  // is skipped until a query has actually run — while the user is still
-  // assembling the folder set (e.g. a working-folder prefill) there's nothing to
-  // recompute yet.
+  // Remove one folder chip and re-scan with the remaining scan sources (same
+  // failure class as the stats module's chips, which used to only setRoots
+  // without re-querying). Clear the workspace only when NOTHING is left to scan
+  // — no remaining roots AND no carried path-globs. A glob-only scope (roots
+  // emptied but carriedGlobs adopted from a Räkna spelare count that mixed
+  // folders + a wildcard) is still a valid source, so removing the last root
+  // must keep scanning the glob, not discard the selection. The re-scan is
+  // skipped until a query has actually run — while the user is still assembling
+  // the folder set (e.g. a working-folder prefill) there's nothing to recompute.
   const removeRoot = useCallback((r) => {
     const remaining = roots.filter((x) => x !== r);
-    if (remaining.length === 0) {
+    if (remaining.length === 0 && carriedGlobs.length === 0) {
       clearWorkspace();
       return;
     }

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -245,6 +245,7 @@ export function CullingModule({ node }) {
     pendingAdvanceRef.current = null;
     ++reqSeqRef.current;
     ++statsSeqRef.current;
+    // Scan scope (the query the workspace describes).
     setRoots([]);
     setCarriedGlobs([]);
     setPlayer('');
@@ -252,12 +253,25 @@ export function CullingModule({ node }) {
     setDateFrom(null);
     setDateTo(null);
     setRecursive(true);
+    // Player dropdown options: these came from the discarded scan. Leaving them
+    // lets the user pick a stale name, which selectPlayer turns into a *name*
+    // glob → canFilter true → Visa POSTs /culling/files with no roots/globs
+    // (empty-scope 400). Empty the list with the working set.
+    setPlayers([]);
+    // File list + selection + grid highlight (all describe the discarded set).
     setFiles([]);
+    setCurrentIndex(-1);
+    setHighlightPlayer('');
+    // Any open inline rename / context menu points at a file that's now gone.
+    setEditPath(null);
+    setEditValue('');
+    setMenu(null);
+    // Stale error from the discarded scan.
+    setError(null);
     // Free the grid's cached thumbnail blobs so a later scope doesn't inherit
     // stale entries (guarded against any in-flight fetch by the cache's
     // generation counter).
     gridThumbnailCache.clear();
-    setCurrentIndex(-1);
     setStats(null);
     // Forget the scan-scope key so a later reload of the SAME scope still
     // re-blanks the panel (loadStats compares against this ref).
@@ -268,6 +282,11 @@ export function CullingModule({ node }) {
     lastQueryRef.current = null;
     setScanScope(null);
     updateWatches(new Set());
+    // Deliberately NOT reset (not workspace scope): undoStackRef (a just-trashed
+    // file can still be restored after clearing — undo keys on file id, not the
+    // scan scope); showTrash (view toggle); preset (the file-type filter is a
+    // sticky choice, re-applied to the next scope); viewMode / column widths /
+    // countSettings (persisted user prefs shared beyond this workspace).
   }, [updateWatches]);
 
   // ----- listing ------------------------------------------------------

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -1325,7 +1325,7 @@ export function CullingModule({ node }) {
       <CullingFilterBar
         addFolders={addFolders}
         clearWorkspace={clearWorkspace}
-        canClear={roots.length > 0 || hasRun || files.length > 0}
+        canClear={roots.length > 0 || carriedGlobs.length > 0 || hasRun || files.length > 0 || isLoading}
         preset={preset}
         setPreset={setPreset}
         runFilter={runFilter}

--- a/frontend/src/renderer/components/CullingModule.jsx
+++ b/frontend/src/renderer/components/CullingModule.jsx
@@ -231,6 +231,18 @@ export function CullingModule({ node }) {
   // repopulating the just-cleared workspace; resets the loading flags because
   // those seq-fenced responses skip their own `finally` cleanup.
   const clearWorkspace = useCallback(() => {
+    // Cancel every pending refresh BEFORE nulling lastQueryRef: both debounced
+    // callbacks read lastQueryRef.current live at fire time, so a scheduled
+    // folder-change refresh (debounceRef) would call loadList(null) → POST
+    // /culling/files with a null body → error instead of the cleared state, and
+    // a scheduled cull/restore stats refresh (statsDebounceRef) would loadStats
+    // a null scope. A scope *change* is self-healing (the ref points at the new
+    // query); only a clear nulls the ref, so this cancellation lives here.
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (statsDebounceRef.current) clearTimeout(statsDebounceRef.current);
+    // Drop any pending rename-advance so a future scan can't inherit a stale
+    // target path from the discarded working set.
+    pendingAdvanceRef.current = null;
     ++reqSeqRef.current;
     ++statsSeqRef.current;
     setRoots([]);

--- a/frontend/src/renderer/components/InputBar.jsx
+++ b/frontend/src/renderer/components/InputBar.jsx
@@ -66,9 +66,12 @@ export function InputBar({
     }
   }, [value, onChange]);
 
+  // Removing a folder chip auto-applies (like the selects) so the parent can
+  // re-run — or clear — its query. Without this, deselecting every folder could
+  // never publish an empty scope: the parent would keep the last non-empty one.
   const removeRoot = useCallback(
-    (root) => patch({ roots: value.roots.filter((r) => r !== root) }),
-    [value.roots, patch]
+    (root) => patchAndApply({ roots: value.roots.filter((r) => r !== root) }),
+    [value.roots, patchAndApply]
   );
 
   const canSubmit = !busy && (value.roots.length > 0 || value.glob.trim() !== '');

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -263,6 +263,12 @@ export function PlayerCountModule() {
         setResult(null);
         setError(null);
         setHasRun(false);
+        // Reset the loading/refresh flags: the reqSeqRef bump fences any
+        // in-flight runCount, so its finally (guarded on the seq) never clears
+        // these — without this the count spinner or the "refreshing" indicator
+        // would stick on the emptied panel.
+        setIsLoading(false);
+        setIsRefreshing(false);
         setScanScope(null);
         updateWatches(new Set());
         return;

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -242,12 +242,23 @@ export function PlayerCountModule() {
   const handleAutoApply = useCallback(
     (nextInput) => {
       setInput(nextInput);
+      // Auto-apply only affects a count that has actually run. Until then there's
+      // nothing to recompute — and, crucially, nothing to clear: publishing an
+      // empty scope here would clobber a selection Gallra spelare published after
+      // this (blank) tab mounted, e.g. from toggling the file-type/recursive
+      // controls without any folder picked.
+      if (!lastParamsRef.current) return;
       // Deselecting every folder (and no glob) clears the count instead of
       // POSTing an empty query — an empty selection would otherwise count the
-      // backend's whole default set. Reset our result and publish an empty scan
-      // scope so Gallra spelare mirrors the cleared selection (it adopts on its
-      // next mount). No /players/count call with empty roots.
+      // backend's whole default set. Publish an empty scan scope so Gallra
+      // spelare mirrors the cleared selection (it adopts on its next mount).
       if (nextInput.roots.length === 0 && nextInput.glob.trim() === '') {
+        // Cancel a scheduled folder-watch refresh and fence any in-flight one:
+        // the debounced callback reads lastParamsRef at fire time (would POST
+        // null params once we null it), and an in-flight runCount would pass its
+        // seq check and repopulate result/hasRun. Bumping reqSeqRef discards it.
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        ++reqSeqRef.current;
         lastParamsRef.current = null;
         setResult(null);
         setError(null);
@@ -256,7 +267,7 @@ export function PlayerCountModule() {
         updateWatches(new Set());
         return;
       }
-      if (lastParamsRef.current) submitWith(nextInput, perMatch);
+      submitWith(nextInput, perMatch);
     },
     [submitWith, perMatch, updateWatches]
   );

--- a/frontend/src/renderer/components/PlayerCountModule.jsx
+++ b/frontend/src/renderer/components/PlayerCountModule.jsx
@@ -242,9 +242,23 @@ export function PlayerCountModule() {
   const handleAutoApply = useCallback(
     (nextInput) => {
       setInput(nextInput);
+      // Deselecting every folder (and no glob) clears the count instead of
+      // POSTing an empty query — an empty selection would otherwise count the
+      // backend's whole default set. Reset our result and publish an empty scan
+      // scope so Gallra spelare mirrors the cleared selection (it adopts on its
+      // next mount). No /players/count call with empty roots.
+      if (nextInput.roots.length === 0 && nextInput.glob.trim() === '') {
+        lastParamsRef.current = null;
+        setResult(null);
+        setError(null);
+        setHasRun(false);
+        setScanScope(null);
+        updateWatches(new Set());
+        return;
+      }
       if (lastParamsRef.current) submitWith(nextInput, perMatch);
     },
-    [submitWith, perMatch]
+    [submitWith, perMatch, updateWatches]
   );
 
   // Counting-option changes apply immediately (like the InputBar selects), but

--- a/frontend/src/renderer/components/culling/FilterBar.jsx
+++ b/frontend/src/renderer/components/culling/FilterBar.jsx
@@ -18,6 +18,8 @@ import { Button } from '../shared/index.js';
 
 export function CullingFilterBar({
   addFolders,
+  clearWorkspace,
+  canClear,
   preset,
   setPreset,
   runFilter,
@@ -39,6 +41,9 @@ export function CullingFilterBar({
   return (
     <div className="culling-filterbar">
       <Button variant="secondary" onClick={addFolders}>{t('culling.filterBar.addFolder')}</Button>
+      <Button variant="secondary" onClick={clearWorkspace} disabled={!canClear}>
+        {t('culling.filterBar.clear')}
+      </Button>
       <select
         className="form-select"
         value={preset}

--- a/frontend/tests/cullingClearWorkspace.test.jsx
+++ b/frontend/tests/cullingClearWorkspace.test.jsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/react';
+import { gridThumbnailCache } from '../src/renderer/shared/grid-thumbnail-cache.js';
+
+// PR "tömbart urval" — Gallra spelare (culling):
+//  - a "Rensa" button empties the workspace (same semantics as CLI --clear),
+//  - the folder chips re-scan on removal (last chip → clearWorkspace),
+// both driven by the shared clearWorkspace() the CLI --clear path now also uses.
+
+const h = vi.hoisted(() => {
+  const registry = new Map();
+  const api = { get: vi.fn(), post: vi.fn() };
+  return { registry, api, nextFiles: { files: [], players: [] }, nextStats: {} };
+});
+
+vi.mock('../src/renderer/context/BackendContext.jsx', () => ({
+  useBackend: () => ({ api: h.api }),
+}));
+
+vi.mock('../src/renderer/hooks/useModuleEvent.js', () => ({
+  useModuleEvent: (eventName, handler) => {
+    if (eventName) h.registry.set(eventName, handler);
+  },
+  useModuleAPI: () => ({
+    emit: vi.fn(),
+    on: () => () => {},
+    waitForListeners: vi.fn().mockResolvedValue(true),
+    hasListeners: () => false,
+  }),
+}));
+
+import { CullingModule } from '../src/renderer/components/CullingModule.jsx';
+import { getScanScope, setScanScope } from '../src/renderer/shared/scanScope.js';
+
+beforeAll(() => {
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (!window.localStorage) {
+    const store = new Map();
+    window.localStorage = {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      clear: () => store.clear(),
+    };
+  }
+});
+
+const FILES = [
+  { path: '/p/260601_120000_Alice.jpg', basename: '260601_120000_Alice.jpg', mtime_ms: 100, size: 10 },
+  { path: '/p/260601_120100_Bob.jpg', basename: '260601_120100_Bob.jpg', mtime_ms: 200, size: 20 },
+];
+const STATS = {
+  baseline: 5,
+  players: [{ name: 'Alice', count: 6, pct: 50, delta_pct: 10, level: 'ok' }],
+  excluded: null,
+};
+
+let originalFetch;
+
+beforeEach(() => {
+  cleanup();
+  h.registry.clear();
+  h.api.get.mockReset();
+  h.api.post.mockReset();
+  h.nextFiles = { files: FILES, players: ['Alice', 'Bob'] };
+  h.nextStats = STATS;
+  h.api.post.mockImplementation((path) => {
+    if (path.includes('/culling/files')) return Promise.resolve(h.nextFiles);
+    if (path.includes('/players/count')) return Promise.resolve(h.nextStats);
+    return Promise.resolve({});
+  });
+  try { localStorage.clear(); } catch { /* ignore */ }
+  originalFetch = global.fetch;
+  global.fetch = vi.fn(() => new Promise(() => {}));
+  globalThis.window.ansiktenAPI = {
+    watchFolder: vi.fn(),
+    unwatchFolder: vi.fn(),
+    onFolderChanged: () => () => {},
+    invoke: vi.fn().mockResolvedValue([]),
+  };
+  setScanScope(null);
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+async function mountCulling(node = null) {
+  let utils;
+  await act(async () => {
+    utils = render(<CullingModule node={node} />);
+    await Promise.resolve();
+  });
+  return utils;
+}
+
+async function loadFiles(roots = ['/p']) {
+  const handler = h.registry.get('culling-load');
+  await act(async () => {
+    await handler({ roots, clear: true, recursive: false });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function lastPost(fragment) {
+  const calls = h.api.post.mock.calls.filter(([p]) => p.includes(fragment));
+  return calls.length ? calls[calls.length - 1][1] : undefined;
+}
+function findButton(container, text) {
+  return [...container.querySelectorAll('.culling-filterbar button')].find(
+    (b) => b.textContent === text
+  );
+}
+
+describe('CullingModule — Rensa button', () => {
+  it('empties the file list, stats, shared scope and thumbnail cache', async () => {
+    const { container } = await mountCulling();
+    await loadFiles(['/p']);
+    expect(container.querySelectorAll('.culling-files li')).toHaveLength(2);
+    // A scope was published by the load.
+    expect(getScanScope()).not.toBeNull();
+
+    const clearSpy = vi.spyOn(gridThumbnailCache, 'clear');
+    const rensa = findButton(container, 'Rensa');
+    expect(rensa).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(rensa);
+      await Promise.resolve();
+    });
+
+    // List + stats emptied, "välj mapp"-hint back, scope cleared, cache freed.
+    expect(container.querySelector('.culling-files li')).toBeNull();
+    expect(container.querySelector('.culling-stat-row')).toBeNull();
+    expect(getScanScope()).toBeNull();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('is disabled when there is nothing to clear', async () => {
+    const { container } = await mountCulling();
+    // Fresh mount, no scope adopted, no roots → nothing to clear.
+    const rensa = findButton(container, 'Rensa');
+    expect(rensa.disabled).toBe(true);
+  });
+});
+
+describe('CullingModule — root chip removal', () => {
+  it('re-scans with the remaining root when one of several chips is removed', async () => {
+    const { container } = await mountCulling();
+    await loadFiles(['/a', '/b']);
+    const before = h.api.post.mock.calls.filter(([p]) => p.includes('/culling/files')).length;
+
+    const removes = container.querySelectorAll('.culling-chip-x');
+    expect(removes).toHaveLength(2);
+    await act(async () => {
+      fireEvent.click(removes[0].closest('button')); // remove '/a'
+      await Promise.resolve();
+    });
+
+    const after = h.api.post.mock.calls.filter(([p]) => p.includes('/culling/files')).length;
+    expect(after).toBe(before + 1);
+    expect(lastPost('/culling/files')).toMatchObject({ roots: ['/b'] });
+  });
+
+  it('removing the last chip clears the workspace', async () => {
+    const { container } = await mountCulling();
+    await loadFiles(['/only']);
+    expect(container.querySelectorAll('.culling-files li')).toHaveLength(2);
+
+    const removes = container.querySelectorAll('.culling-chip-x');
+    expect(removes).toHaveLength(1);
+    await act(async () => {
+      fireEvent.click(removes[0].closest('button'));
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.culling-files li')).toBeNull();
+    expect(container.querySelector('.culling-chip')).toBeNull();
+    expect(getScanScope()).toBeNull();
+  });
+});

--- a/frontend/tests/cullingClearWorkspace.test.jsx
+++ b/frontend/tests/cullingClearWorkspace.test.jsx
@@ -232,3 +232,25 @@ describe('CullingModule — clear cancels pending refreshes (Codex round 2)', ()
     expect(getScanScope()).toBeNull();
   });
 });
+
+describe('CullingModule — clear/chip state consistency (Codex round 3)', () => {
+  // Fynd 5: clearWorkspace must empty the player dropdown too — a stale name
+  // would let selectPlayer set a *name* glob (canFilter true) and Visa would
+  // then POST /culling/files with no roots/globs (empty-scope 400).
+  it('empties the player dropdown on Rensa (no stale names to pick)', async () => {
+    const { container } = await mountCulling();
+    await loadFiles(['/p']); // players: ['Alice', 'Bob']
+    const selectBefore = container.querySelectorAll('.culling-filterbar select.form-select')[1];
+    expect([...selectBefore.options].map((o) => o.value)).toContain('Alice');
+
+    const rensa = findButton(container, 'Rensa');
+    await act(async () => {
+      fireEvent.click(rensa);
+      await Promise.resolve();
+    });
+
+    // Only the "Alla spelare" placeholder (value '') remains.
+    const selectAfter = container.querySelectorAll('.culling-filterbar select.form-select')[1];
+    expect([...selectAfter.options].map((o) => o.value)).toEqual(['']);
+  });
+});

--- a/frontend/tests/cullingClearWorkspace.test.jsx
+++ b/frontend/tests/cullingClearWorkspace.test.jsx
@@ -285,3 +285,49 @@ describe('CullingModule — clear/chip state consistency (Codex round 3)', () =>
     expect(container.querySelectorAll('.culling-files li').length).toBeGreaterThan(0);
   });
 });
+
+describe('CullingModule — clear enabled during in-flight adopt (Codex round 4)', () => {
+  // Fynd 7: adopting a glob-only scope (globs, no roots) starts an active scan
+  // while roots/files are empty and hasRun is still false. canClear must not be
+  // disabled during that expensive scan — the user has to be able to clear it.
+  it('keeps Rensa enabled while a glob-only adopt scan is in flight, and clearing fences it', async () => {
+    // /culling/files hangs so the adopt scan stays in flight.
+    let resolveFiles;
+    h.api.post.mockImplementation((path) => {
+      if (path.includes('/culling/files')) return new Promise((res) => { resolveFiles = res; });
+      if (path.includes('/players/count')) return Promise.resolve(h.nextStats);
+      return Promise.resolve({});
+    });
+    // A glob-only shared scope to adopt on mount (no roots).
+    setScanScope({
+      roots: [],
+      globs: ['*.jpg'],
+      recursive: true,
+      date_from: null,
+      date_to: null,
+      extension_preset: 'jpg',
+    });
+
+    const { container } = await mountCulling();
+
+    // Mid-scan: no roots, no files, hasRun false — but a glob scope + an active
+    // scan mean there IS something to clear. Rensa must be enabled.
+    expect(container.querySelectorAll('.culling-files li')).toHaveLength(0);
+    const rensa = findButton(container, 'Rensa');
+    expect(rensa.disabled).toBe(false);
+
+    // Clearing fences the in-flight scan (per the earlier sweep).
+    await act(async () => {
+      fireEvent.click(rensa);
+      await Promise.resolve();
+    });
+    // The hung scan resolves AFTER the clear: it must not repopulate.
+    await act(async () => {
+      resolveFiles(h.nextFiles);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('.culling-files li')).toBeNull();
+    expect(getScanScope()).toBeNull();
+  });
+});

--- a/frontend/tests/cullingClearWorkspace.test.jsx
+++ b/frontend/tests/cullingClearWorkspace.test.jsx
@@ -253,4 +253,35 @@ describe('CullingModule — clear/chip state consistency (Codex round 3)', () =>
     const selectAfter = container.querySelectorAll('.culling-filterbar select.form-select')[1];
     expect([...selectAfter.options].map((o) => o.value)).toEqual(['']);
   });
+
+  // Fynd 6: removing the last root chip while a carried path-glob (adopted from a
+  // Räkna spelare count that mixed folders + a wildcard) is still present must
+  // re-scan the glob-only scope, not clear the workspace.
+  it('keeps a glob-only carried scope when the last root chip is removed', async () => {
+    const { container } = await mountCulling();
+    // cull-player hand-off carries both a root and a path-glob.
+    const cullPlayer = h.registry.get('cull-player');
+    await act(async () => {
+      await cullPlayer({ roots: ['/a'], globs: ['*.jpg'], recursive: true, name: '' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelectorAll('.culling-chip-x')).toHaveLength(1);
+    expect(getScanScope()).not.toBeNull();
+    const before = h.api.post.mock.calls.filter(([p]) => p.includes('/culling/files')).length;
+
+    // Remove the only root chip.
+    const remove = container.querySelector('.culling-chip-x');
+    await act(async () => {
+      fireEvent.click(remove.closest('button'));
+      await Promise.resolve();
+    });
+
+    // Re-scanned as a glob-only scope (roots empty, glob kept) — NOT cleared.
+    const after = h.api.post.mock.calls.filter(([p]) => p.includes('/culling/files')).length;
+    expect(after).toBe(before + 1);
+    expect(lastPost('/culling/files')).toMatchObject({ roots: [], globs: ['*.jpg'] });
+    expect(getScanScope()).not.toBeNull();
+    expect(container.querySelectorAll('.culling-files li').length).toBeGreaterThan(0);
+  });
 });

--- a/frontend/tests/cullingClearWorkspace.test.jsx
+++ b/frontend/tests/cullingClearWorkspace.test.jsx
@@ -7,6 +7,9 @@ import { gridThumbnailCache } from '../src/renderer/shared/grid-thumbnail-cache.
 //  - the folder chips re-scan on removal (last chip → clearWorkspace),
 // both driven by the shared clearWorkspace() the CLI --clear path now also uses.
 
+// REFRESH_DEBOUNCE_MS in CullingModule (not exported); waits use a margin.
+const REFRESH_MS = 400;
+
 const h = vi.hoisted(() => {
   const registry = new Map();
   const api = { get: vi.fn(), post: vi.fn() };
@@ -183,6 +186,49 @@ describe('CullingModule — root chip removal', () => {
 
     expect(container.querySelector('.culling-files li')).toBeNull();
     expect(container.querySelector('.culling-chip')).toBeNull();
+    expect(getScanScope()).toBeNull();
+  });
+});
+
+describe('CullingModule — clear cancels pending refreshes (Codex round 2)', () => {
+  it('clearing while a folder-watch refresh is scheduled does not POST a null query', async () => {
+    let folderCb = null;
+    globalThis.window.ansiktenAPI = {
+      watchFolder: vi.fn(),
+      unwatchFolder: vi.fn(),
+      onFolderChanged: (cb) => { folderCb = cb; return () => {}; },
+      invoke: vi.fn().mockResolvedValue([]),
+    };
+    const { container } = await mountCulling();
+    await loadFiles(['/p']);
+
+    // Schedule a debounced folder-change refresh (its callback reads
+    // lastQueryRef.current at fire time — null after a clear → loadList(null)).
+    expect(typeof folderCb).toBe('function');
+    folderCb();
+
+    // Clear the workspace (Rensa) while that timer is pending.
+    const rensa = findButton(container, 'Rensa');
+    const filesBefore = h.api.post.mock.calls.filter(([p]) => p.includes('/culling/files')).length;
+    await act(async () => {
+      fireEvent.click(rensa);
+      await Promise.resolve();
+    });
+
+    // Wait past the debounce window: the cancelled refresh must never fire.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, REFRESH_MS + 100));
+    });
+
+    const filesAfter = h.api.post.mock.calls.filter(([p]) => p.includes('/culling/files')).length;
+    expect(filesAfter).toBe(filesBefore);
+    // Specifically: no /culling/files POST with a null/undefined body.
+    const nullBody = h.api.post.mock.calls.filter(
+      ([p, body]) => p.includes('/culling/files') && body == null
+    );
+    expect(nullBody).toHaveLength(0);
+    // Workspace stays cleared.
+    expect(container.querySelector('.culling-files li')).toBeNull();
     expect(getScanScope()).toBeNull();
   });
 });

--- a/frontend/tests/playerCountChipClear.test.jsx
+++ b/frontend/tests/playerCountChipClear.test.jsx
@@ -204,6 +204,8 @@ describe('PlayerCountModule — clearing guards (Codex P2 fixes)', () => {
     folderCb(); // schedule the debounced refresh
     await new Promise((r) => setTimeout(r, REFRESH_MS + 50)); // let it fire
     expect(countCalls().length).toBe(2); // refresh is in flight
+    // The silent refresh turned the "refreshing" indicator on.
+    expect(container.querySelector('.player-count-refreshing')).not.toBeNull();
 
     // Remove the only chip → empty clear branch must fence the in-flight refresh.
     const remove = container.querySelector('.input-bar-chip-remove');
@@ -212,6 +214,11 @@ describe('PlayerCountModule — clearing guards (Codex P2 fixes)', () => {
       expect(container.querySelector('.input-bar-chip-remove')).toBeNull()
     );
 
+    // Fynd 4: the clear releases the refresh spinner even though the fenced
+    // request's finally never runs (it can't repopulate, but it also can't clean
+    // up its own flag).
+    expect(container.querySelector('.player-count-refreshing')).toBeNull();
+
     // The stale refresh resolves AFTER the clear: it must NOT repopulate.
     resolveRefresh(populated);
     await new Promise((r) => setTimeout(r, 0));
@@ -219,6 +226,8 @@ describe('PlayerCountModule — clearing guards (Codex P2 fixes)', () => {
     expect(getScanScope()).toBeNull();
     // Empty-state prompt is (still) shown — the late response did not repopulate.
     expect(screen.getByText('Räkna', { selector: 'strong' })).toBeTruthy();
+    // And the spinner stayed off after the late resolve.
+    expect(container.querySelector('.player-count-refreshing')).toBeNull();
   });
 
   // Fynd 2 (scheduled variant): removing the only chip while a refresh is merely

--- a/frontend/tests/playerCountChipClear.test.jsx
+++ b/frontend/tests/playerCountChipClear.test.jsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Chip removal in Räkna spelare must publish the (possibly empty) scan scope and
+// recount — or clear. Before the fix, InputBar's removeRoot only patched local
+// state without firing onAutoApply, so deselecting a folder never recounted and
+// an empty selection could never be published (Gallra kept adopting the last
+// non-empty scope).
+
+const { postMock, getMock } = vi.hoisted(() => ({
+  postMock: vi.fn().mockResolvedValue({
+    total_images: 0,
+    files_resolved: 0,
+    players: [],
+    excluded: null,
+    baseline: 0,
+    baseline_method: 'median',
+    time_range: null,
+  }),
+  getMock: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../src/renderer/context/BackendContext.jsx', () => ({
+  useBackend: () => ({ api: { post: postMock, get: getMock } }),
+}));
+
+vi.mock('../src/renderer/hooks/useModuleEvent.js', () => ({
+  useModuleEvent: () => {},
+  useModuleAPI: () => ({
+    emit: vi.fn(),
+    on: () => () => {},
+    waitForListeners: vi.fn().mockResolvedValue(true),
+    hasListeners: () => false,
+  }),
+}));
+
+import { PlayerCountModule } from '../src/renderer/components/PlayerCountModule.jsx';
+import { getScanScope, setScanScope } from '../src/renderer/shared/scanScope.js';
+
+const countCalls = () =>
+  postMock.mock.calls.filter(([url]) => url === '/api/v1/players/count');
+
+describe('PlayerCountModule — chip removal publishes/clears scan scope', () => {
+  beforeEach(() => {
+    postMock.mockClear();
+    getMock.mockClear();
+    globalThis.window.ansiktenAPI = {
+      watchFolder: vi.fn(),
+      unwatchFolder: vi.fn(),
+      onFolderChanged: () => () => {},
+      invoke: vi.fn().mockResolvedValue([]),
+    };
+    // Seed a two-folder scope so the adopt-on-mount effect runs an initial count
+    // (and renders two removable chips).
+    setScanScope({
+      roots: ['/photos/a', '/photos/b'],
+      globs: [],
+      recursive: true,
+      date_from: null,
+      date_to: null,
+      extension_preset: 'jpg',
+    });
+  });
+
+  it('removing one chip recounts with the remaining root and reduces the shared scope', async () => {
+    const { container } = render(<PlayerCountModule />);
+    await waitFor(() => expect(countCalls().length).toBe(1));
+    postMock.mockClear();
+
+    const removes = container.querySelectorAll('.input-bar-chip-remove');
+    expect(removes).toHaveLength(2);
+    fireEvent.click(removes[0]); // remove '/photos/a'
+
+    await waitFor(() => expect(countCalls().length).toBe(1));
+    expect(countCalls()[0][1]).toEqual(expect.objectContaining({ roots: ['/photos/b'] }));
+    expect(getScanScope()).toEqual(expect.objectContaining({ roots: ['/photos/b'] }));
+  });
+
+  it('removing the last chip clears without a count and empties the shared scope', async () => {
+    const { container } = render(<PlayerCountModule />);
+    await waitFor(() => expect(countCalls().length).toBe(1));
+
+    // Remove both chips one at a time.
+    let removes = container.querySelectorAll('.input-bar-chip-remove');
+    fireEvent.click(removes[0]);
+    await waitFor(() => {
+      expect(container.querySelectorAll('.input-bar-chip-remove')).toHaveLength(1);
+    });
+    postMock.mockClear();
+
+    removes = container.querySelectorAll('.input-bar-chip-remove');
+    fireEvent.click(removes[0]); // remove the last one → empty selection
+
+    await waitFor(() => {
+      // No chips left, and the empty-state prompt is back.
+      expect(container.querySelectorAll('.input-bar-chip-remove')).toHaveLength(0);
+    });
+    // No POST fired for the empty selection.
+    expect(countCalls().length).toBe(0);
+    // Shared scope cleared and folder watches released.
+    expect(getScanScope()).toBeNull();
+    expect(window.ansiktenAPI.unwatchFolder).toHaveBeenCalled();
+    // Empty-state prompt (the "Räkna" call-to-action) is shown again.
+    expect(screen.getByText('Räkna', { selector: 'strong' })).toBeTruthy();
+  });
+});

--- a/frontend/tests/playerCountChipClear.test.jsx
+++ b/frontend/tests/playerCountChipClear.test.jsx
@@ -1,14 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
+// REFRESH_DEBOUNCE_MS in PlayerCountModule (not exported); waits use a margin.
+const REFRESH_MS = 400;
+
 // Chip removal in Räkna spelare must publish the (possibly empty) scan scope and
 // recount — or clear. Before the fix, InputBar's removeRoot only patched local
 // state without firing onAutoApply, so deselecting a folder never recounted and
 // an empty selection could never be published (Gallra kept adopting the last
 // non-empty scope).
 
-const { postMock, getMock } = vi.hoisted(() => ({
-  postMock: vi.fn().mockResolvedValue({
+const { postMock, getMock, api } = vi.hoisted(() => {
+  const postMock = vi.fn().mockResolvedValue({
     total_images: 0,
     files_resolved: 0,
     players: [],
@@ -16,12 +19,17 @@ const { postMock, getMock } = vi.hoisted(() => ({
     baseline: 0,
     baseline_method: 'median',
     time_range: null,
-  }),
-  getMock: vi.fn().mockResolvedValue({}),
-}));
+  });
+  const getMock = vi.fn().mockResolvedValue({});
+  // Stable api object: PlayerCountModule's folder-watch effect depends on
+  // runCount, which depends on `api`. A fresh object per render would re-run
+  // that effect and clear any pending debounce — masking the very timers these
+  // tests exercise. The real backend api is a singleton, so mirror that here.
+  return { postMock, getMock, api: { post: postMock, get: getMock } };
+});
 
 vi.mock('../src/renderer/context/BackendContext.jsx', () => ({
-  useBackend: () => ({ api: { post: postMock, get: getMock } }),
+  useBackend: () => ({ api }),
 }));
 
 vi.mock('../src/renderer/hooks/useModuleEvent.js', () => ({
@@ -102,5 +110,152 @@ describe('PlayerCountModule — chip removal publishes/clears scan scope', () =>
     expect(window.ansiktenAPI.unwatchFolder).toHaveBeenCalled();
     // Empty-state prompt (the "Räkna" call-to-action) is shown again.
     expect(screen.getByText('Räkna', { selector: 'strong' })).toBeTruthy();
+  });
+});
+
+describe('PlayerCountModule — clearing guards (Codex P2 fixes)', () => {
+  beforeEach(() => {
+    postMock.mockClear();
+    postMock.mockResolvedValue({
+      total_images: 0,
+      files_resolved: 0,
+      players: [],
+      excluded: null,
+      baseline: 0,
+      baseline_method: 'median',
+      time_range: null,
+    });
+    getMock.mockClear();
+    globalThis.window.ansiktenAPI = {
+      watchFolder: vi.fn(),
+      unwatchFolder: vi.fn(),
+      onFolderChanged: () => () => {},
+      invoke: vi.fn().mockResolvedValue([]),
+    };
+  });
+
+  // Fynd 1: a blank tab that never ran a count must NOT clear the shared scope on
+  // an empty auto-apply — that would clobber a selection Gallra published after
+  // this tab mounted.
+  it('a blank-tab auto-apply does not clobber a scope published after mount', async () => {
+    setScanScope(null); // no scope to adopt → this tab never counts
+    const { container } = render(<PlayerCountModule />);
+    await waitFor(() => expect(getMock).toHaveBeenCalled()); // mount settled
+    // Nothing adopted, no chips, no count.
+    expect(container.querySelectorAll('.input-bar-chip-remove')).toHaveLength(0);
+    expect(countCalls().length).toBe(0);
+
+    // Gallra publishes a scope AFTER this tab mounted.
+    setScanScope({
+      roots: ['/gallra'],
+      globs: [],
+      recursive: true,
+      date_from: null,
+      date_to: null,
+      extension_preset: 'jpg',
+    });
+
+    // Toggle the file-type control on the still-blank tab → an empty auto-apply.
+    const preset = screen.getByTitle('Filtyper (skiftlägesokänsligt)');
+    fireEvent.change(preset, { target: { value: 'nef' } });
+    await Promise.resolve();
+
+    // The scope Gallra published survives untouched; still no count fired.
+    expect(getScanScope()).toEqual(expect.objectContaining({ roots: ['/gallra'] }));
+    expect(countCalls().length).toBe(0);
+  });
+
+  // Fynd 2: removing the only chip while a folder-watch refresh is in flight must
+  // fence that request (seq bump) so its late response can't repopulate the
+  // just-cleared result.
+  it('removing the only chip fences an in-flight folder-watch refresh', async () => {
+    setScanScope({
+      roots: ['/solo'],
+      globs: [],
+      recursive: true,
+      date_from: null,
+      date_to: null,
+      extension_preset: 'jpg',
+    });
+    let folderCb = null;
+    globalThis.window.ansiktenAPI = {
+      watchFolder: vi.fn(),
+      unwatchFolder: vi.fn(),
+      onFolderChanged: (cb) => { folderCb = cb; return () => {}; },
+      invoke: vi.fn().mockResolvedValue([]),
+    };
+    const populated = {
+      total_images: 3,
+      files_resolved: 3,
+      players: [{ name: 'A', count: 3, pct: 100, delta_pct: 0, delta_n: 0, level: 'ok', timestamps: [] }],
+      excluded: null,
+      baseline: 3,
+      baseline_method: 'median',
+      time_range: null,
+    };
+    postMock.mockResolvedValue(populated);
+
+    const { container } = render(<PlayerCountModule />);
+    await waitFor(() => expect(countCalls().length).toBe(1)); // adopt count
+
+    // The next count (the folder-watch refresh) hangs → stays in flight.
+    let resolveRefresh;
+    postMock.mockImplementationOnce(() => new Promise((res) => { resolveRefresh = res; }));
+    folderCb(); // schedule the debounced refresh
+    await new Promise((r) => setTimeout(r, REFRESH_MS + 50)); // let it fire
+    expect(countCalls().length).toBe(2); // refresh is in flight
+
+    // Remove the only chip → empty clear branch must fence the in-flight refresh.
+    const remove = container.querySelector('.input-bar-chip-remove');
+    fireEvent.click(remove);
+    await waitFor(() =>
+      expect(container.querySelector('.input-bar-chip-remove')).toBeNull()
+    );
+
+    // The stale refresh resolves AFTER the clear: it must NOT repopulate.
+    resolveRefresh(populated);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getScanScope()).toBeNull();
+    // Empty-state prompt is (still) shown — the late response did not repopulate.
+    expect(screen.getByText('Räkna', { selector: 'strong' })).toBeTruthy();
+  });
+
+  // Fynd 2 (scheduled variant): removing the only chip while a refresh is merely
+  // debounce-scheduled must cancel the timer so it can't POST null params.
+  it('removing the only chip cancels a scheduled folder-watch refresh', async () => {
+    setScanScope({
+      roots: ['/solo'],
+      globs: [],
+      recursive: true,
+      date_from: null,
+      date_to: null,
+      extension_preset: 'jpg',
+    });
+    let folderCb = null;
+    globalThis.window.ansiktenAPI = {
+      watchFolder: vi.fn(),
+      unwatchFolder: vi.fn(),
+      onFolderChanged: (cb) => { folderCb = cb; return () => {}; },
+      invoke: vi.fn().mockResolvedValue([]),
+    };
+
+    const { container } = render(<PlayerCountModule />);
+    await waitFor(() => expect(countCalls().length).toBe(1)); // adopt count
+
+    folderCb(); // schedule (but do not yet fire) a debounced refresh
+    postMock.mockClear();
+
+    // Remove the only chip → empty clear branch must clearTimeout the refresh.
+    const remove = container.querySelector('.input-bar-chip-remove');
+    fireEvent.click(remove);
+    await waitFor(() =>
+      expect(container.querySelector('.input-bar-chip-remove')).toBeNull()
+    );
+
+    // Wait past the debounce window: the cancelled refresh must never POST.
+    await new Promise((r) => setTimeout(r, REFRESH_MS + 100));
+    expect(countCalls().length).toBe(0);
+    expect(getScanScope()).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

The shared scan scope (sessionStorage, adopted on module mount) could never become empty:

- Removing a folder chip in Räkna spelare only updated local input state — no recount, no scope publish — and the submit button is disabled on an empty selection, so an emptied selection was never published. The culling view kept adopting the last non-empty scope, resurrecting the previous selection's images.
- The culling view had no clear affordance at all; the only clear path was the CLI \`ansikten culling --clear\`.
- The culling view's own root chips likewise only \`setRoots(...)\` without rescanning.

## Changes

- **Räkna spelare:** chip removal now auto-applies. A reduced selection recounts and publishes the reduced scope; removing the last folder (no glob) clears the result and publishes an empty scope (\`setScanScope(null)\`) without POSTing an empty query, and drops folder watches.
- **Gallra:** the CLI bare \`--clear\` body is extracted into a reusable \`clearWorkspace()\` and a new "Rensa" button in the filter bar invokes it (disabled when there is nothing to clear). Root-chip removal now rescans with the remaining roots; removing the last chip clears the workspace.
- Deliberately out of scope: no live scanScope subscription — modules still adopt on mount (Räkna's local input is untouched by a culling-side clear).

## Tests

New \`frontend/tests/playerCountChipClear.test.jsx\` and \`frontend/tests/cullingClearWorkspace.test.jsx\`. Full suite after rebase onto dev: 67 files / 619 tests passed; \`npm run build:workspace\` clean.

## Docs

CHANGELOG \`[Unreleased]\` updated; "Rensa" documented in \`docs/user/workspace-guide.md\`.