### PR TITLE
(review) Shared resolveSuggestion: unify displayed and applied name suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog is initialized from git commit history after `v1.0.0` and can be 
 
 ## [Unreleased]
 
+### Fixed
+- **Namnförslaget i bildvisaren och accept-tangenterna kan inte längre divergera.** Boxetiketten i bildvisaren och de olika accept-vägarna i Granska ansikten (Enter/bekräfta-tangent, "Godta alla", ConfirmDialog-grindningen) plockade tidigare namnet från olika håll: bildvisaren föredrog `face.person_name` medan accept-vägarna använde `match_alternatives[0]`. På äldre cachade svar där `person_name` och det översta alternativet inte stämde överens kunde etiketten alltså visa ett annat namn än det som en accept faktiskt skrev. En ny delad resolver `resolveSuggestion(face)` (i `review/reviewActions.js`) är nu enda källan för det föreslagna namnet: för obekräftade ansikten hämtar **både** visning (den utbrutna `review/faceLabel.js` + FaceCard-prefill/badges) och handling (accept-tangenter, `getTopMatch`, `acceptAllState`) namnet därifrån, medan bekräftade ansikten visar användarens beslut (`person_name`). `match_case`-formateringen i etiketten är oförändrad.
+
 ### Added
 - **"Rensa"-knapp i Gallra-vyns filterrad.** En ny sekundärknapp **Rensa** (efter "+ Mapp") tömmer gallringsarbetsytan tillbaka till "välj mapp"-läget — fillista, räknekolumn, cachade miniatyrer och mappbevakning nollställs och det delade skanningsscopet rensas — med exakt samma semantik som CLI:t `ansikten culling --clear`. Knappen är avaktiverad när det inte finns något att rensa. CLI:ts `--clear`-väg och knappen delar nu en gemensam `clearWorkspace()`-rutin.
 

--- a/frontend/src/renderer/components/ImageViewer.jsx
+++ b/frontend/src/renderer/components/ImageViewer.jsx
@@ -24,6 +24,7 @@ import { ZOOM_STEP } from '../shared/canvasViewport.js';
 import { apiClient } from '../shared/api-client.js';
 import { preferences } from '../workspace/preferences.js';
 import { CanvasImageView } from './CanvasImageView.jsx';
+import { buildFaceLabel } from './review/faceLabel.js';
 import { LoadingOverlay } from './shared/ProgressBar.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import { t } from '../../i18n/index.js';
@@ -267,32 +268,7 @@ export function ImageViewer() {
       let labelWidth = 0;
       let labelHeight = 0;
 
-      let labelText = null;
-      const matchCase = face.match_case;
-
-      const getFirstAlternativeName = () => {
-        if (face.person_name) return face.person_name;
-        const first = face.match_alternatives?.[0];
-        if (!first) return t('imageViewer.unknown');
-        return first.is_ignored ? 'ign' : first.name;
-      };
-
-      if (matchCase === 'ign') {
-        labelText = `${faceNumber}. ign (${(face.ignore_confidence || 0)}%)`;
-      } else if (matchCase === 'uncertain_ign') {
-        labelText = `${faceNumber}. ign (${(face.ignore_confidence || 0)}%) / ${getFirstAlternativeName()}`;
-      } else if (matchCase === 'uncertain_name') {
-        labelText = `${faceNumber}. ${getFirstAlternativeName()} / ign (${(face.ignore_confidence || 0)}%)`;
-      } else if (face.person_name) {
-        labelText = `${faceNumber}. ${face.person_name} (${((face.confidence || 0) * 100).toFixed(0)}%)`;
-      } else if (face.match_alternatives?.length > 0) {
-        const best = face.match_alternatives[0];
-        labelText = best.is_ignored
-          ? `${faceNumber}. ign? (${best.confidence}%)`
-          : `${faceNumber}. ${best.name}? (${best.confidence}%)`;
-      } else {
-        labelText = `${faceNumber}. ${t('imageViewer.unknown')}`;
-      }
+      const labelText = buildFaceLabel(face, faceNumber, t);
 
       if (labelText) {
         const metrics = ctx.measureText(labelText);

--- a/frontend/src/renderer/components/ReviewModule.jsx
+++ b/frontend/src/renderer/components/ReviewModule.jsx
@@ -29,6 +29,7 @@ import { useReviewKeyboard } from './review/useReviewKeyboard.js';
 import { useActiveTabset } from '../hooks/useActiveTabset.js';
 import {
   getTopMatch as getTopMatchPure,
+  resolveSuggestion,
   willAllBeDone,
   nextFaceIndex,
   confirmFaceState,
@@ -714,12 +715,12 @@ export function ReviewModule({ node }) {
 
       if (inputValue) {
         confirmFace(currentFaceIndex, inputValue);
-      } else if (currentFace?.match_alternatives?.length > 0) {
-        const firstAlt = currentFace.match_alternatives[0];
-        if (firstAlt.is_ignored || firstAlt.name === 'ign') {
+      } else {
+        const suggestion = resolveSuggestion(currentFace);
+        if (suggestion?.isIgnore) {
           ignoreFace(currentFaceIndex);
-        } else {
-          confirmFace(currentFaceIndex, firstAlt.name);
+        } else if (suggestion) {
+          confirmFace(currentFaceIndex, suggestion.name);
         }
       }
     },
@@ -731,12 +732,12 @@ export function ReviewModule({ node }) {
       const input = inputRefs.current[currentFaceIndex];
       if (input?.value?.trim()) {
         confirmFace(currentFaceIndex, input.value);
-      } else if (currentFace?.match_alternatives?.length > 0) {
-        const firstAlt = currentFace.match_alternatives[0];
-        if (firstAlt.is_ignored || firstAlt.name === 'ign') {
+      } else {
+        const suggestion = resolveSuggestion(currentFace);
+        if (suggestion?.isIgnore) {
           ignoreFace(currentFaceIndex);
-        } else {
-          confirmFace(currentFaceIndex, firstAlt.name);
+        } else if (suggestion) {
+          confirmFace(currentFaceIndex, suggestion.name);
         }
       }
     },

--- a/frontend/src/renderer/components/review/FaceCard.jsx
+++ b/frontend/src/renderer/components/review/FaceCard.jsx
@@ -10,12 +10,27 @@ import React, { useState } from 'react';
 import { useThumbnail } from '../../shared/thumbnail-cache.js';
 import { Autocomplete } from '../shared/Autocomplete.jsx';
 import { rank } from './nameAutocomplete.js';
+import { resolveSuggestion } from './reviewActions.js';
 import { Icon } from '../Icon.jsx';
 import { t } from '../../../i18n/index.js';
 
+/**
+ * Name to prefill the autocomplete with for an unconfirmed face. Only the
+ * name-suggestion cases prefill, and never the 'ign' sentinel — everything
+ * else starts empty. Derived from the shared resolveSuggestion so the prefill
+ * matches what the accept keys would apply.
+ * @param {Object} face
+ * @returns {string}
+ */
+function prefillName(face) {
+  if (face.match_case !== 'name' && face.match_case !== 'uncertain_name') return '';
+  const suggestion = resolveSuggestion(face);
+  if (!suggestion || suggestion.isIgnore) return '';
+  return suggestion.name;
+}
+
 export function FaceCard({ face, index, isActive, imagePath, people, cardRef, inputRef, onSelect, onConfirm, onIgnore, onUnconfirm, maxAlternatives, onSelectAlternative, clearInputTrigger }) {
-  const isProbableIgnoreCase = face.match_case === 'ign' || face.match_case === 'uncertain_ign';
-  const initialValue = isProbableIgnoreCase ? '' : (face.person_name || '');
+  const initialValue = prefillName(face);
   const [inputValue, setInputValue] = useState(initialValue);
   const [typedValue, setTypedValue] = useState(initialValue);
 
@@ -25,11 +40,14 @@ export function FaceCard({ face, index, isActive, imagePath, people, cardRef, in
     face.bounding_box
   );
 
+  const topAlternativeName = face.match_alternatives?.[0]?.name;
   React.useEffect(() => {
-    const newValue = isProbableIgnoreCase ? '' : (face.person_name || '');
+    const newValue = prefillName(face);
     setInputValue(newValue);
     setTypedValue(newValue);
-  }, [face.face_id, face.match_case, isProbableIgnoreCase, face.person_name]);
+    // topAlternativeName drives prefillName alongside match_case; listed so a
+    // changed suggestion re-syncs the input.
+  }, [face.face_id, face.match_case, topAlternativeName]); // eslint-disable-line react-hooks/exhaustive-deps
 
   React.useEffect(() => {
     if (clearInputTrigger > 0) {
@@ -45,6 +63,10 @@ export function FaceCard({ face, index, isActive, imagePath, people, cardRef, in
 
   // Determine if this is a probable-ignore case
   const isProbableIgnore = face.match_case === 'ign' || face.match_case === 'uncertain_ign';
+
+  // Name shown in the uncertain badges — from the shared resolver so it
+  // matches what an accept would apply (badges only render for unconfirmed).
+  const suggestionName = resolveSuggestion(face)?.name || t('review.unknown');
 
   const cardClass = [
     'face-card',
@@ -91,7 +113,7 @@ export function FaceCard({ face, index, isActive, imagePath, people, cardRef, in
           <div className="match-case uncertain">
             {t('review.badges.uncertainIgn', {
               conf: face.ignore_confidence,
-              name: face.person_name || face.match_alternatives?.[0]?.name || t('review.unknown'),
+              name: suggestionName,
             })}
           </div>
         )}
@@ -99,7 +121,7 @@ export function FaceCard({ face, index, isActive, imagePath, people, cardRef, in
           <div className="match-case uncertain">
             {t('review.badges.uncertainName', {
               conf: face.ignore_confidence,
-              name: face.person_name || face.match_alternatives?.[0]?.name || t('review.unknown'),
+              name: suggestionName,
             })}
           </div>
         )}

--- a/frontend/src/renderer/components/review/faceLabel.js
+++ b/frontend/src/renderer/components/review/faceLabel.js
@@ -1,0 +1,51 @@
+/**
+ * faceLabel - Pure builder for the ImageViewer face-box label text.
+ *
+ * Extracted from ImageViewer.drawFaceBoxes so the match_case formatting can be
+ * unit tested and, crucially, so the name shown in the label comes from the
+ * same {@link resolveSuggestion} resolver the accept paths use. That closes the
+ * gap where the box label could show `person_name` while the accept keys
+ * applied `match_alternatives[0]` (e.g. on older cached responses).
+ */
+
+import { resolveSuggestion } from './reviewActions.js';
+
+/**
+ * Build the label drawn over a face box.
+ *
+ * Confirmed faces show the user's decision (`person_name`); unconfirmed faces
+ * are formatted per `match_case`, with the suggested name always taken from
+ * {@link resolveSuggestion} so display can never diverge from what an accept
+ * would apply.
+ *
+ * @param {Object} face - Detected face (bounding_box, match_case, alternatives…).
+ * @param {number} faceNumber - 1-based label prefix.
+ * @param {(key: string) => string} t - i18n lookup (for the "unknown" fallback).
+ * @returns {string} Label text, e.g. `3. Anna? (82%)`.
+ */
+export function buildFaceLabel(face, faceNumber, t) {
+  const matchCase = face.match_case;
+  const suggestion = resolveSuggestion(face);
+
+  // Name for the match-heuristic branches, always via the shared resolver.
+  const suggestionName = () => {
+    if (!suggestion) return t('imageViewer.unknown');
+    return suggestion.isIgnore ? 'ign' : suggestion.name;
+  };
+
+  if (matchCase === 'ign') {
+    return `${faceNumber}. ign (${face.ignore_confidence || 0}%)`;
+  } else if (matchCase === 'uncertain_ign') {
+    return `${faceNumber}. ign (${face.ignore_confidence || 0}%) / ${suggestionName()}`;
+  } else if (matchCase === 'uncertain_name') {
+    return `${faceNumber}. ${suggestionName()} / ign (${face.ignore_confidence || 0}%)`;
+  } else if (face.is_confirmed) {
+    // The user's decision wins over any suggestion.
+    return `${faceNumber}. ${face.person_name} (${((face.confidence || 0) * 100).toFixed(0)}%)`;
+  } else if (suggestion) {
+    return suggestion.isIgnore
+      ? `${faceNumber}. ign? (${suggestion.confidence}%)`
+      : `${faceNumber}. ${suggestion.name}? (${suggestion.confidence}%)`;
+  }
+  return `${faceNumber}. ${t('imageViewer.unknown')}`;
+}

--- a/frontend/src/renderer/components/review/faceLabel.js
+++ b/frontend/src/renderer/components/review/faceLabel.js
@@ -33,15 +33,22 @@ export function buildFaceLabel(face, faceNumber, t) {
     return suggestion.isIgnore ? 'ign' : suggestion.name;
   };
 
+  // Confirmed faces reflect the user's decision — evaluated before the
+  // match_case branches so a corrected name on an uncertain_* face overrides
+  // the (now stale) top alternative instead of being shadowed by it.
+  if (face.is_confirmed) {
+    if (face.is_rejected) {
+      return `${faceNumber}. ign (${face.ignore_confidence || 0}%)`;
+    }
+    return `${faceNumber}. ${face.person_name} (${((face.confidence || 0) * 100).toFixed(0)}%)`;
+  }
+
   if (matchCase === 'ign') {
     return `${faceNumber}. ign (${face.ignore_confidence || 0}%)`;
   } else if (matchCase === 'uncertain_ign') {
     return `${faceNumber}. ign (${face.ignore_confidence || 0}%) / ${suggestionName()}`;
   } else if (matchCase === 'uncertain_name') {
     return `${faceNumber}. ${suggestionName()} / ign (${face.ignore_confidence || 0}%)`;
-  } else if (face.is_confirmed) {
-    // The user's decision wins over any suggestion.
-    return `${faceNumber}. ${face.person_name} (${((face.confidence || 0) * 100).toFixed(0)}%)`;
   } else if (suggestion) {
     return suggestion.isIgnore
       ? `${faceNumber}. ign? (${suggestion.confidence}%)`

--- a/frontend/src/renderer/components/review/reviewActions.js
+++ b/frontend/src/renderer/components/review/reviewActions.js
@@ -12,17 +12,43 @@
 export const HIGH_CONFIDENCE_THRESHOLD = 75;
 
 /**
- * Return the top match alternative if it is high-confidence and not an
- * ignore suggestion, else null. Drives the ConfirmDialog gating.
+ * The single source of truth for "what does the app suggest for this face".
+ * Both the box label (display) and every accept path (action) derive the
+ * suggestion from here, so display and action can never diverge — including
+ * for older cached responses where `person_name` may disagree with the
+ * top alternative.
+ *
+ * Confirmed faces are the user's decision, not a suggestion: callers that
+ * care show `person_name` for `is_confirmed` faces and only fall back to
+ * this resolver for unconfirmed ones.
+ *
+ * @param {Object} face
+ * @returns {{name: string, confidence: number, isIgnore: boolean}|null}
+ *   null when there is no top alternative to suggest.
+ */
+export function resolveSuggestion(face) {
+  const top = face?.match_alternatives?.[0];
+  if (!top) return null;
+  return {
+    name: top.name,
+    confidence: top.confidence,
+    isIgnore: !!top.is_ignored || top.name === 'ign',
+  };
+}
+
+/**
+ * Return the suggested match if it is high-confidence and not an ignore
+ * suggestion, else null. Thin wrapper over {@link resolveSuggestion} that
+ * applies the ConfirmDialog gating threshold.
  * @param {Object} face
  * @param {number} [threshold=HIGH_CONFIDENCE_THRESHOLD]
  * @returns {{name: string, confidence: number}|null}
  */
 export function getTopMatch(face, threshold = HIGH_CONFIDENCE_THRESHOLD) {
-  if (!face?.match_alternatives?.length) return null;
-  const top = face.match_alternatives[0];
-  if (top.confidence >= threshold && !top.is_ignored) {
-    return { name: top.name, confidence: top.confidence };
+  const suggestion = resolveSuggestion(face);
+  if (!suggestion || suggestion.isIgnore) return null;
+  if (suggestion.confidence >= threshold) {
+    return { name: suggestion.name, confidence: suggestion.confidence };
   }
   return null;
 }
@@ -171,13 +197,13 @@ export function acceptAllState(faces, imagePath) {
   const updatedFaces = faces.map((face) => {
     if (face.is_confirmed) return face;
 
-    const firstAlt = face.match_alternatives?.[0];
-    if (!firstAlt) {
+    const suggestion = resolveSuggestion(face);
+    if (!suggestion) {
       skipped++;
       return face;
     }
 
-    if (firstAlt.is_ignored || firstAlt.name === 'ign') {
+    if (suggestion.isIgnore) {
       ignored++;
       if (face.face_id) {
         ignores.push({ face_id: face.face_id, image_path: imagePath });
@@ -185,7 +211,7 @@ export function acceptAllState(faces, imagePath) {
       return { ...face, is_confirmed: true, is_rejected: true, person_name: '(ignored)' };
     }
 
-    const trimmedName = firstAlt.name?.trim() || firstAlt.name;
+    const trimmedName = suggestion.name?.trim() || suggestion.name;
     accepted++;
 
     if (face.face_id) {

--- a/frontend/tests/faceLabel.test.js
+++ b/frontend/tests/faceLabel.test.js
@@ -19,6 +19,49 @@ describe('buildFaceLabel — formatting branches', () => {
     expect(buildFaceLabel(f, 3, t)).toBe('3. Anna (82%)');
   });
 
+  it('confirmed uncertain_name face shows the corrected name, not the stale top alternative', () => {
+    // match_case and alternatives survive confirmation (confirmFaceState only
+    // flips is_confirmed/person_name); the confirmed branch must win.
+    const f = face({
+      is_confirmed: true,
+      person_name: 'Corrected',
+      confidence: 0.9,
+      match_case: 'uncertain_name',
+      ignore_confidence: 30,
+      match_alternatives: [{ name: 'Anna', confidence: 70 }],
+    });
+    const label = buildFaceLabel(f, 2, t);
+    expect(label).toBe('2. Corrected (90%)');
+    expect(label).not.toContain('Anna');
+    expect(label).not.toContain('ign');
+  });
+
+  it('confirmed uncertain_ign face shows the corrected name, not ign', () => {
+    const f = face({
+      is_confirmed: true,
+      person_name: 'Corrected',
+      confidence: 0.88,
+      match_case: 'uncertain_ign',
+      ignore_confidence: 40,
+      match_alternatives: [{ name: 'ign', confidence: 65, is_ignored: true }],
+    });
+    expect(buildFaceLabel(f, 1, t)).toBe('1. Corrected (88%)');
+  });
+
+  it('confirmed-as-ignored face reads as ign regardless of match_case', () => {
+    const f = face({
+      is_confirmed: true,
+      is_rejected: true,
+      person_name: '(ignored)',
+      match_case: 'uncertain_name',
+      ignore_confidence: 55,
+      match_alternatives: [{ name: 'Anna', confidence: 70 }],
+    });
+    const label = buildFaceLabel(f, 4, t);
+    expect(label).toBe('4. ign (55%)');
+    expect(label).not.toContain('Anna');
+  });
+
   it('ign case shows the ignore confidence only', () => {
     const f = face({ match_case: 'ign', ignore_confidence: 50, match_alternatives: [{ name: 'ign', confidence: 80, is_ignored: true }] });
     expect(buildFaceLabel(f, 1, t)).toBe('1. ign (50%)');

--- a/frontend/tests/faceLabel.test.js
+++ b/frontend/tests/faceLabel.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { buildFaceLabel } from '../src/renderer/components/review/faceLabel.js';
+import { resolveSuggestion, acceptAllState } from '../src/renderer/components/review/reviewActions.js';
+
+// Stub i18n: identity lookup keeps the "unknown" fallback deterministic and
+// independent of the Swedish string table.
+const t = (key) => key;
+
+const face = (overrides = {}) => ({
+  face_id: 'f1',
+  is_confirmed: false,
+  match_alternatives: [],
+  ...overrides,
+});
+
+describe('buildFaceLabel — formatting branches', () => {
+  it('confirmed face shows the user decision (person_name + confidence)', () => {
+    const f = face({ is_confirmed: true, person_name: 'Anna', confidence: 0.82 });
+    expect(buildFaceLabel(f, 3, t)).toBe('3. Anna (82%)');
+  });
+
+  it('ign case shows the ignore confidence only', () => {
+    const f = face({ match_case: 'ign', ignore_confidence: 50, match_alternatives: [{ name: 'ign', confidence: 80, is_ignored: true }] });
+    expect(buildFaceLabel(f, 1, t)).toBe('1. ign (50%)');
+  });
+
+  it('uncertain_ign shows ign then the suggested name', () => {
+    const f = face({ match_case: 'uncertain_ign', ignore_confidence: 40, match_alternatives: [{ name: 'Bertil', confidence: 65 }] });
+    expect(buildFaceLabel(f, 2, t)).toBe('2. ign (40%) / Bertil');
+  });
+
+  it('uncertain_name shows the suggested name then ign', () => {
+    const f = face({ match_case: 'uncertain_name', ignore_confidence: 30, match_alternatives: [{ name: 'Cecilia', confidence: 70 }] });
+    expect(buildFaceLabel(f, 2, t)).toBe('2. Cecilia / ign (30%)');
+  });
+
+  it('name suggestion (unconfirmed) shows tentative name with a question mark', () => {
+    const f = face({ match_case: 'name', match_alternatives: [{ name: 'David', confidence: 77 }] });
+    expect(buildFaceLabel(f, 4, t)).toBe('4. David? (77%)');
+  });
+
+  it('ignore suggestion (unconfirmed) shows a tentative ign', () => {
+    const f = face({ match_alternatives: [{ name: 'ign', confidence: 55, is_ignored: true }] });
+    expect(buildFaceLabel(f, 4, t)).toBe('4. ign? (55%)');
+  });
+
+  it('falls back to unknown when there is nothing to suggest', () => {
+    expect(buildFaceLabel(face({ match_case: 'unknown' }), 5, t)).toBe('5. imageViewer.unknown');
+    expect(buildFaceLabel(face(), 6, t)).toBe('6. imageViewer.unknown');
+  });
+
+  it('never prefers person_name over the top alternative for unconfirmed faces', () => {
+    // Older cached response: person_name disagrees with the top alternative.
+    const f = face({ match_case: 'name', person_name: 'STALE', match_alternatives: [{ name: 'David', confidence: 77 }] });
+    const label = buildFaceLabel(f, 1, t);
+    expect(label).toContain('David');
+    expect(label).not.toContain('STALE');
+  });
+});
+
+// Consistency property: for unconfirmed faces, the name the box label shows
+// must equal the name the accept paths would apply. acceptAllState is the
+// accept oracle here (single-face array); confirmations carry the applied
+// name, ignores mean "ign", skips mean nothing to apply.
+describe('buildFaceLabel ⇄ accept consistency (unconfirmed faces)', () => {
+  const fixtures = {
+    name: face({ face_id: 'a', match_case: 'name', match_alternatives: [{ name: 'David', confidence: 77 }] }),
+    uncertain_name: face({ face_id: 'b', match_case: 'uncertain_name', ignore_confidence: 30, match_alternatives: [{ name: 'Cecilia', confidence: 70 }] }),
+    uncertain_ign: face({ face_id: 'c', match_case: 'uncertain_ign', ignore_confidence: 40, match_alternatives: [{ name: 'ign', confidence: 65, is_ignored: true }] }),
+    ign: face({ face_id: 'd', match_case: 'ign', ignore_confidence: 50, match_alternatives: [{ name: 'ign', confidence: 80, is_ignored: true }] }),
+    unknown: face({ face_id: 'e', match_case: 'unknown', match_alternatives: [] }),
+    empty: face({ face_id: 'f', match_alternatives: [] }),
+    diverging_person_name: face({ face_id: 'g', match_case: 'name', person_name: 'STALE', match_alternatives: [{ name: 'David', confidence: 77 }] }),
+  };
+
+  for (const [name, f] of Object.entries(fixtures)) {
+    it(`${name}: label name matches what accept applies`, () => {
+      const label = buildFaceLabel(f, 1, t);
+      const { confirmations, ignores, skipped } = acceptAllState([f], '/p.jpg');
+
+      if (confirmations.length > 0) {
+        // Accept confirms a name -> that exact name must appear in the label.
+        expect(label).toContain(confirmations[0].person_name);
+        // And never a stale person_name the accept path ignores.
+        if (f.person_name && f.person_name !== confirmations[0].person_name) {
+          expect(label).not.toContain(f.person_name);
+        }
+      } else if (ignores.length > 0) {
+        // Accept ignores -> the label must read as an ignore.
+        expect(label).toContain('ign');
+        expect(resolveSuggestion(f).isIgnore).toBe(true);
+      } else {
+        // Nothing to apply (skipped) -> label is the unknown fallback.
+        expect(skipped).toBe(1);
+        expect(label).toBe('1. imageViewer.unknown');
+      }
+    });
+  }
+});

--- a/frontend/tests/reviewActions.test.js
+++ b/frontend/tests/reviewActions.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   getTopMatch,
+  resolveSuggestion,
   willAllBeDone,
   nextFaceIndex,
   confirmFaceState,
@@ -27,6 +28,40 @@ const face = (overrides = {}) => ({
   is_confirmed: false,
   match_alternatives: [],
   ...overrides,
+});
+
+describe('resolveSuggestion', () => {
+  it('returns null when there is no top alternative', () => {
+    expect(resolveSuggestion(face())).toBeNull();          // empty alternatives
+    expect(resolveSuggestion(face({ match_alternatives: undefined }))).toBeNull();
+    expect(resolveSuggestion(null)).toBeNull();
+    expect(resolveSuggestion(undefined)).toBeNull();
+  });
+
+  it('resolves the normal (name) case from the first alternative', () => {
+    const f = face({ match_alternatives: [{ name: 'Anna', confidence: 82 }] });
+    expect(resolveSuggestion(f)).toEqual({ name: 'Anna', confidence: 82, isIgnore: false });
+  });
+
+  it('flags isIgnore when the top alternative is is_ignored', () => {
+    const f = face({ match_alternatives: [{ name: 'Skomakare', confidence: 60, is_ignored: true }] });
+    expect(resolveSuggestion(f)).toEqual({ name: 'Skomakare', confidence: 60, isIgnore: true });
+  });
+
+  it("flags isIgnore when the top alternative name is the 'ign' sentinel", () => {
+    const f = face({ match_alternatives: [{ name: 'ign', confidence: 70 }] });
+    expect(resolveSuggestion(f)).toEqual({ name: 'ign', confidence: 70, isIgnore: true });
+  });
+
+  it('only ever considers the FIRST alternative', () => {
+    const f = face({
+      match_alternatives: [
+        { name: 'Anna', confidence: 60 },
+        { name: 'Berit', confidence: 95, is_ignored: true },
+      ],
+    });
+    expect(resolveSuggestion(f)).toEqual({ name: 'Anna', confidence: 60, isIgnore: false });
+  });
 });
 
 describe('getTopMatch', () => {


### PR DESCRIPTION
## Problem

The suggestion shown in the ImageViewer face-box label could differ from the one the review-module accept keys apply: the label preferred `face.person_name` while every accept path used `match_alternatives[0]`. Acting on the displayed name could apply a different name.

## Fix

One shared resolver, used by every surface:

- `reviewActions.js`: new `resolveSuggestion(face)` → `{name, confidence, isIgnore}` (null when no top alternative). `getTopMatch` is now a thin wrapper; `acceptAllState` refactored onto it.
- New `review/faceLabel.js`: `buildFaceLabel(face, faceNumber, t)` extracted from ImageViewer — every branch's name comes from `resolveSuggestion`; `match_case` formatting unchanged; confirmed faces still show `person_name`. The person_name-first preference for unconfirmed faces is removed.
- `FaceCard.jsx`: prefill/badges via the resolver; never prefills the literal `'ign'`.
- `ReviewModule.jsx`: `confirmEnter`/`confirmKey` refactored onto the resolver. `selectAlternative` (explicit index choice) untouched.

Display and action can no longer diverge — even for older cached detection responses. Event-flow/index sync is a separate follow-up PR. Backend root-cause fix is #228.

## Tests

- New `faceLabel.test.js` (15) + extended `reviewActions.test.js` (24), incl. a consistency property: for name/uncertain_name/uncertain_ign/ign/unknown/empty fixtures and `person_name ≠ alternatives[0].name`, the label name for unconfirmed faces equals the name the accept paths apply.
- Full frontend suite: 68 files, 646 tests, all passing.

## Notes

Behavior tightening: `getTopMatch` now treats a top alternative named `'ign'` without `is_ignored` as ignore (returns null) — stricter and consistent; only affects ConfirmDialog gating.