### PR TITLE
docs(claude): switch the commit format to conventional commits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ shared guidance, update CLAUDE.md (canonical) and mirror anything essential here
 
 ## Git
 - `master` is protected; `dev` is the main branch — branch features off `dev`, PR into `dev`.
-- Commit format: `(scope) description` — `(filename)`, `(feature)`, or `(type)` (fix/docs/style/refactor/perf/test/chore).
+- Commit format: Conventional Commits — `type(scope): subject` (mandatory scope, English, imperative subject). The bare `(scope) description` style seen in older history is retired — do not imitate it.
 
 ## Testing (run before pushing)
 - Backend: `cd backend && pytest`  (tests in `backend/tests/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,18 @@ git push origin feature/my-feature
 - **Never** add "Generated with Claude" footers
 - **Never** add "Co-Authored-By: Claude"
 
-Format: `(scope) description`
-- `(filename)` for single file
-- `(feature)` for multi-file feature
-- `(type)` for general changes (fix, docs, refactor)
+Format: **Conventional Commits 1.0** — `type(scope): subject`
+- `type`: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+- `scope` is mandatory: a filename without extension (`luarc`) or a
+  module/feature name (`auth`, `midi-probe`)
+- Subject: imperative mood, lowercase first letter, no trailing period,
+  ≤ 72 characters
+- Breaking change: `type(scope)!: subject` plus a footer
+  `BREAKING CHANGE: <description>`
+- English only; no monolith commits — one logical change per commit
+
+> **History note:** older commits use the retired bare `(scope) description`
+> format. Do not imitate it — every new commit follows Conventional Commits.
 
 ---
 


### PR DESCRIPTION
Retires the bare `(scope) description` commit style in favour of Conventional Commits 1.0 (`type(scope): subject`), per the all-repo convention. Adds a history note so the old pattern in the log is not imitated, and mirrors the change into the Copilot instructions (which inline the essentials and do not follow links).

Docs-only, meta change — bot review skipped per the quota-hushållning rule for trivial prose.