### PR TITLE
feat(midi): enable Web MIDI for the workspace

### DIFF
--- a/frontend/src/main/permissions.js
+++ b/frontend/src/main/permissions.js
@@ -34,6 +34,11 @@ const WORKSPACE_PERMISSIONS = Object.freeze([
   // navigator.clipboard.writeText() behind the "copy logs" button in
   // LogViewer; Chromium routes writeText through clipboard-sanitized-write.
   'clipboard-sanitized-write',
+  // navigator.requestMIDIAccess() behind shared/midi/client.js — the
+  // X-TOUCH MINI control surface. Chromium refuses the request unless BOTH
+  // names are allowed, even though nothing here sends SysEx yet.
+  'midi',
+  'midiSysex',
 ]);
 
 /**

--- a/frontend/src/renderer/shared/debug.js
+++ b/frontend/src/renderer/shared/debug.js
@@ -17,6 +17,7 @@ const DEFAULT_CATEGORIES = {
   'FlexLayout': false,
   'Backend': true,
   'WebSocket': true,
+  'MIDI': true,
   'ModuleAPI': false,
   'ModuleEvent': false,
   'FileQueue': false,

--- a/frontend/src/renderer/shared/midi/client.js
+++ b/frontend/src/renderer/shared/midi/client.js
@@ -1,0 +1,159 @@
+/**
+ * Web MIDI client for the X-TOUCH MINI control surface.
+ *
+ * Always-on by design: it connects when the workspace boots if the device is
+ * present and stays quiet otherwise. Hot-plug recovery is driven by the
+ * MIDIAccess statechange event, which fires when a device appears or leaves;
+ * rescan() is the guaranteed manual path for the cases where Chromium's event
+ * fails to fire — the same gap that makes MIDI2LR users click "rescan".
+ *
+ * Chromium grants requestMIDIAccess only when both the 'midi' and 'midiSysex'
+ * session permissions are allowlisted, even though this module requests
+ * access without sending SysEx today (verified 2026-08-23). Measured wire
+ * facts live in docs/dev/midi.md.
+ */
+
+const DEVICE_NAME = 'X-TOUCH MINI';
+
+/**
+ * Create the workspace MIDI client.
+ *
+ * @param {object} [options]
+ * @param {string} [options.name] - device name to match ports against.
+ * @param {Navigator} [options.nav] - injectable navigator for tests.
+ * @param {(data: Uint8Array, timeStamp: number, event: MIDIMessageEvent) => void} [options.onMessage]
+ * @param {(status: string, detail?: string) => void} [options.onStatus]
+ *        statuses: 'connected' | 'no-device' | 'denied' | 'unsupported' |
+ *        'disconnected'. Repeats are suppressed.
+ * @param {(msg: string) => void} [options.log]
+ */
+export function createMidiClient({
+  name = DEVICE_NAME,
+  nav = globalThis.navigator,
+  onMessage = () => {},
+  onStatus = () => {},
+  log = () => {},
+} = {}) {
+  let access = null;
+  let input = null;
+  let output = null;
+  let inFlight = null;
+  let lastStatus = '';
+
+  function setStatus(status, detail) {
+    if (status === lastStatus) return;
+    lastStatus = status;
+    onStatus(status, detail);
+    log(`status: ${status}${detail ? ` (${detail})` : ''}`);
+  }
+
+  function detach() {
+    if (input) input.onmidimessage = null;
+    input = null;
+    output = null;
+  }
+
+  /**
+   * Re-evaluate which ports to bind on the current access object.
+   * @returns {boolean} true when our input is bound.
+   */
+  function attachPorts() {
+    if (!access) return false;
+    const inputs = [...access.inputs.values()].filter((p) => p.name === name);
+    const outputs = [...access.outputs.values()].filter((p) => p.name === name);
+    const nextInput = inputs[0] || null;
+    const nextOutput = outputs[0] || null;
+    if (nextInput && nextInput === input && nextOutput === output) return true;
+    detach();
+    input = nextInput;
+    output = nextOutput;
+    if (!input) {
+      setStatus('no-device', `waiting for "${name}"`);
+      return false;
+    }
+    input.onmidimessage = (event) =>
+      onMessage(event.data, event.timeStamp, event);
+    log(`bound "${name}": ${inputs.length} in / ${outputs.length} out`);
+    setStatus('connected');
+    return true;
+  }
+
+  function onStateChange() {
+    attachPorts();
+  }
+
+  /**
+   * Run the requestMIDIAccess handshake. Safe to call repeatedly; concurrent
+   * calls share one handshake and a bound client short-circuits to a re-scan
+   * of its existing access object.
+   */
+  async function connect() {
+    if (access) {
+      attachPorts();
+      return;
+    }
+    if (inFlight) return inFlight;
+    if (!nav.requestMIDIAccess) {
+      setStatus('unsupported', 'navigator.requestMIDIAccess saknas');
+      return;
+    }
+    inFlight = (async () => {
+      try {
+        log('requesting MIDI access…');
+        access = await nav.requestMIDIAccess({ sysex: true });
+      } catch (err) {
+        setStatus('denied', err?.message || String(err));
+        inFlight = null;
+        return;
+      }
+      access.addEventListener('statechange', onStateChange);
+      attachPorts();
+      inFlight = null;
+    })();
+    await inFlight;
+  }
+
+  /**
+   * Guaranteed manual recovery: re-evaluate the current access object, and
+   * if that yields nothing (or there never was one), redo the whole
+   * handshake once.
+   */
+  async function rescan() {
+    if (access && attachPorts()) return true;
+    log('rescanning…');
+    if (access) {
+      access.removeEventListener('statechange', onStateChange);
+      detach();
+      access = null;
+    }
+    await connect();
+    return Boolean(input);
+  }
+
+  /** Drop every binding and listener; a later connect() starts fresh. */
+  function disconnect() {
+    if (access) access.removeEventListener('statechange', onStateChange);
+    detach();
+    access = null;
+    inFlight = null;
+    setStatus('disconnected');
+  }
+
+  /** Send raw bytes to the device output; a no-op while unbound. */
+  function send(bytes) {
+    output?.send(bytes);
+  }
+
+  return {
+    connect,
+    rescan,
+    disconnect,
+    send,
+    get connected() {
+      return Boolean(input);
+    },
+    get deviceName() {
+      return name;
+    },
+  };
+}

--- a/frontend/src/renderer/workspace/flexlayout/index.jsx
+++ b/frontend/src/renderer/workspace/flexlayout/index.jsx
@@ -15,6 +15,7 @@ import { ConfirmProvider } from '../../context/ConfirmContext.jsx';
 import { NotificationListener } from '../../components/NotificationListener.jsx';
 import { ConnectionStatus } from '../../components/ConnectionStatus.jsx';
 import { debug, debugError } from '../../shared/debug.js';
+import { createMidiClient } from '../../shared/midi/client.js';
 
 // Import theme system (must be first among CSS imports to define variables)
 import '../../theme.css';
@@ -65,6 +66,15 @@ function initFlexLayoutWorkspace() {
   );
 
   debug('FlexLayout', 'Workspace initialized');
+
+  // X-TOUCH MINI control surface: always-on Web MIDI. Quiet no-op when the
+  // device is absent; statechange drives hot-plug recovery, and the message
+  // consumer arrives with the MIDI input layer.
+  const midi = createMidiClient({
+    log: (msg) => debug('MIDI', msg),
+    onStatus: (status, detail) => debug('MIDI', `status ${status}`, detail),
+  });
+  midi.connect().catch((err) => debugError('MIDI', 'connect failed', err));
 }
 
 // Initialize when DOM is ready

--- a/frontend/tests/midi/client.test.js
+++ b/frontend/tests/midi/client.test.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMidiClient } from '../../src/renderer/shared/midi/client.js';
+
+/** A MIDIAccess stand-in: Maps of ports plus a statechange listener list. */
+function fakeAccess(ports) {
+  const listeners = new Map();
+  return {
+    inputs: new Map(ports.inputs.map((p) => [p.id, p])),
+    outputs: new Map(ports.outputs.map((p) => [p.id, p])),
+    addEventListener(type, fn) {
+      listeners.set(type, fn);
+    },
+    removeEventListener(type) {
+      listeners.delete(type);
+    },
+    fireStateChange() {
+      listeners.get('statechange')?.({ port: null });
+    },
+  };
+}
+
+function port(id, name, kind) {
+  return { id, name, type: kind, state: 'connected', onmidimessage: null };
+}
+
+const XTOUCH_IN = () => port('in1', 'X-TOUCH MINI', 'input');
+const XTOUCH_OUT = () => port('out1', 'X-TOUCH MINI', 'output');
+
+function clientWith(accessFactory, overrides = {}) {
+  const requestMIDIAccess = vi.fn(async () => accessFactory());
+  const client = createMidiClient({
+    nav: { requestMIDIAccess },
+    log: () => {},
+    ...overrides,
+  });
+  return { client, requestMIDIAccess };
+}
+
+describe('midi client', () => {
+  it('binds the matched input and forwards its messages', async () => {
+    const xtouchIn = XTOUCH_IN();
+    const onMessage = vi.fn();
+    const { client } = clientWith(
+      () =>
+        fakeAccess({
+          inputs: [xtouchIn],
+          outputs: [XTOUCH_OUT()],
+        }),
+      { onMessage },
+    );
+
+    await client.connect();
+
+    expect(client.connected).toBe(true);
+    expect(xtouchIn.onmidimessage).toBeTypeOf('function');
+    xtouchIn.onmidimessage({ data: new Uint8Array([0xba, 1, 64]), timeStamp: 5 });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual(new Uint8Array([0xba, 1, 64]));
+    expect(onMessage.mock.calls[0][1]).toBe(5);
+  });
+
+  it('leaves other devices unbound and reports no-device when absent', async () => {
+    const other = port('iac1', 'IAC Driver Bus 1', 'input');
+    const statuses = [];
+    const onStatus = (s) => statuses.push(s);
+    const { client } = clientWith(
+      () => fakeAccess({ inputs: [other], outputs: [] }),
+      { onStatus },
+    );
+
+    await client.connect();
+
+    expect(other.onmidimessage).toBeNull();
+    expect(client.connected).toBe(false);
+    expect(statuses.at(-1)).toBe('no-device');
+  });
+
+  it('reattaches via statechange when the device appears later', async () => {
+    const access = fakeAccess({ inputs: [], outputs: [] });
+    const { client } = clientWith(() => access);
+
+    await client.connect();
+    expect(client.connected).toBe(false);
+
+    // Hot-plug: Web MIDI mutates the same access object and fires the event.
+    const xtouchIn = XTOUCH_IN();
+    access.inputs.set(xtouchIn.id, xtouchIn);
+    access.outputs.set('out1', XTOUCH_OUT());
+    access.fireStateChange();
+
+    expect(client.connected).toBe(true);
+    expect(xtouchIn.onmidimessage).toBeTypeOf('function');
+  });
+
+  it('reports denied when the handshake rejects', async () => {
+    const statuses = [];
+    const nav = {
+      requestMIDIAccess: vi.fn(async () => {
+        throw new Error('Permission to use Web MIDI API was not granted.');
+      }),
+    };
+    const client = createMidiClient({
+      nav,
+      onStatus: (s) => statuses.push(s),
+      log: () => {},
+    });
+
+    await client.connect();
+
+    expect(statuses.at(-1)).toBe('denied');
+    expect(client.connected).toBe(false);
+  });
+
+  it('reports unsupported without requestMIDIAccess', async () => {
+    const statuses = [];
+    const client = createMidiClient({
+      nav: {},
+      onStatus: (s) => statuses.push(s),
+      log: () => {},
+    });
+
+    await client.connect();
+
+    expect(statuses.at(-1)).toBe('unsupported');
+  });
+
+  it('disconnect detaches the handler and removes the statechange listener', async () => {
+    const access = fakeAccess({
+      inputs: [XTOUCH_IN()],
+      outputs: [XTOUCH_OUT()],
+    });
+    const onMessage = vi.fn();
+    const { client } = clientWith(() => access, { onMessage });
+
+    await client.connect();
+    expect(client.connected).toBe(true);
+
+    client.disconnect();
+    expect(client.connected).toBe(false);
+
+    access.fireStateChange();
+    [...access.inputs.values()].forEach((p) => {
+      p.onmidimessage?.({ data: [], timeStamp: 0 });
+    });
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('rescan redoes the handshake when nothing was connected', async () => {
+    let hasDevice = false;
+    const nav = {
+      requestMIDIAccess: vi.fn(async () =>
+        fakeAccess(hasDevice
+          ? { inputs: [XTOUCH_IN()], outputs: [XTOUCH_OUT()] }
+          : { inputs: [], outputs: [] }),
+      ),
+    };
+    const client = createMidiClient({ nav, log: () => {} });
+
+    await client.connect();
+    expect(client.connected).toBe(false);
+
+    hasDevice = true; // the user plugged the device back in
+    const reconnected = await client.rescan();
+
+    expect(reconnected).toBe(true);
+    expect(client.connected).toBe(true);
+    expect(nav.requestMIDIAccess).toHaveBeenCalledTimes(2);
+  });
+
+  it('rescan returns true immediately while already bound', async () => {
+    const { client, requestMIDIAccess } = clientWith(() =>
+      fakeAccess({ inputs: [XTOUCH_IN()], outputs: [XTOUCH_OUT()] }));
+
+    await client.connect();
+    const ok = await client.rescan();
+
+    expect(ok).toBe(true);
+    expect(requestMIDIAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('requests access with SysEx capability enabled', async () => {
+    const { client, requestMIDIAccess } = clientWith(() =>
+      fakeAccess({ inputs: [XTOUCH_IN()], outputs: [XTOUCH_OUT()] }));
+
+    await client.connect();
+
+    expect(requestMIDIAccess).toHaveBeenCalledWith({ sysex: true });
+  });
+});

--- a/frontend/tests/permissions.test.js
+++ b/frontend/tests/permissions.test.js
@@ -38,10 +38,15 @@ describe('permission policy — deny by default', () => {
     expect(decide('unknown')).toBe(false);
   });
 
-  it('allowlists clipboard write for the workspace, nothing else', () => {
-    // Every entry needs a caller in the renderer today; midi belongs in the
-    // change that actually calls requestMIDIAccess, not ahead of it.
-    expect([...WORKSPACE_PERMISSIONS]).toEqual(['clipboard-sanitized-write']);
+  it('allowlists clipboard write and midi for the workspace, nothing else', () => {
+    // Every entry needs a caller in the renderer today: clipboard backs
+    // LogViewer's copy button; midi/midiSysex back shared/midi/client.js
+    // (Chromium requires both names even though nothing sends SysEx yet).
+    expect([...WORKSPACE_PERMISSIONS]).toEqual([
+      'clipboard-sanitized-write',
+      'midi',
+      'midiSysex',
+    ]);
   });
 
   it('logs each denied request and names the permission and origin', () => {


### PR DESCRIPTION
Fas 6 etapp 1 ([ROADMAP-planen](https://github.com/krissen/ansikten/blob/dev/ROADMAP.md)). Lägger tillbaka `midi` + `midiSysex` i workspace-sessionens allowlista — callern är ny `shared/midi/client.js`, en always-on Web MIDI-klient för X-TOUCH MINI:

- **Auto-connect vid boot**, tyst no-op utan enhet (beslut: ingen preferens-toggle än — den kommer med mappnings-UI i etapp 4)
- **Hot-plug via `statechange`** — primär mekanism; M2LR:s rescan-knapp-behov finns inte i Web MIDI
- **`rescan()`** som garanterad manuell räddningsväg om eventet sviker (synlig yta kommer i etapp 2:s LogViewer-knapp)
- Båda behörigheterna krävs av Chromium även utan SysEx-användning — verifierat mot hårdvara 2026-08-23

**Verifiering:** vitest (9 nya client-fall + uppdaterad exakt-innehållsassertion, 947/947 grönt), esbuild-bygget OK. Live-check mot enhet görs inför merge.